### PR TITLE
Enforce strict token validation everywhere.

### DIFF
--- a/Okta.AspNet.Abstractions.Test/StrictTokenHandlerShould.cs
+++ b/Okta.AspNet.Abstractions.Test/StrictTokenHandlerShould.cs
@@ -1,0 +1,298 @@
+﻿// <copyright file="StrictTokenHandlerShould.cs" company="Okta, Inc">
+// Copyright (c) 2018-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Okta.AspNet.Abstractions.Test
+{
+    public class StrictTokenHandlerShould
+    {
+        [Fact]
+        public void AllowGoodToken()
+        {
+            var fakeIssuer = "example.okta.com";
+            var fakeAudience = "aud://default";
+
+            using (RSACryptoServiceProvider rsaCryptoServiceProvider = new RSACryptoServiceProvider(2048))
+            {
+                RSAParameters rsaKeyInfo = rsaCryptoServiceProvider.ExportParameters(true);
+                var rsaSecurityKey = new RsaSecurityKey(rsaKeyInfo);
+
+                var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+
+                var jwtContents = new JwtSecurityToken(
+                    issuer: fakeIssuer,
+                    audience: fakeAudience,
+                    expires: DateTime.UtcNow.Add(TimeSpan.FromMinutes(1)),
+                    signingCredentials: signingCredentials);
+
+                var jwt = new JwtSecurityTokenHandler().WriteToken(jwtContents);
+
+                var fakeOktaWebOptions = new OktaWebOptions
+                {
+                    OktaDomain = fakeIssuer,
+                };
+
+                var handler = new StrictTokenHandler();
+
+                var validationParameters = new DefaultTokenValidationParameters(fakeOktaWebOptions, fakeIssuer)
+                {
+                    IssuerSigningKey = signingCredentials.Key,
+                    ValidAudience = fakeAudience,
+                };
+
+                handler.ValidateToken(jwt, validationParameters, out _);
+            }
+        }
+
+        [Fact]
+        public void RejectInvalidAlg()
+        {
+            var fakeIssuer = "example.okta.com";
+            var fakeAudience = "aud://default";
+
+            var credentials = new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
+                SecurityAlgorithms.HmacSha256);
+
+            // Create the JWT and write it to a string
+            var jwtContents = new JwtSecurityToken(
+                issuer: fakeIssuer,
+                audience: fakeAudience,
+                expires: DateTime.UtcNow.Add(TimeSpan.FromMinutes(1)),
+                signingCredentials: credentials);
+            var jwt = new JwtSecurityTokenHandler().WriteToken(jwtContents);
+
+            var fakeOktaWebOptions = new OktaWebOptions
+            {
+                OktaDomain = fakeIssuer,
+            };
+
+            var handler = new StrictTokenHandler();
+
+            var validationParameters = new DefaultTokenValidationParameters(fakeOktaWebOptions, fakeIssuer)
+            {
+                IssuerSigningKey = credentials.Key,
+                ValidAudience = fakeAudience,
+            };
+
+            Action act = () => handler.ValidateToken(
+                jwt,
+                validationParameters,
+                out _);
+
+            act.Should().Throw<SecurityTokenValidationException>().WithMessage("The alg must be RS256.");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("bad")]
+        public void RejectBadToken(string badToken)
+        {
+            var fakeOktaWebOptions = new OktaWebOptions
+            {
+                OktaDomain = "example.okta.com",
+            };
+            var fakeIssuer = "example.okta.com";
+
+            var handler = new StrictTokenHandler();
+
+            Action act = () => handler.ValidateToken(
+                badToken,
+                new DefaultTokenValidationParameters(fakeOktaWebOptions, fakeIssuer),
+                out _);
+
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void RejectExpiredToken()
+        {
+            var fakeIssuer = "example.okta.com";
+            var fakeAudience = "aud://default";
+            var fakeClient = "fakeClient";
+
+            var claims = new Claim[]
+            {
+                new Claim("cid", fakeClient),
+            };
+
+            using (RSACryptoServiceProvider rsaCryptoServiceProvider = new RSACryptoServiceProvider(2048))
+            {
+                RSAParameters rsaKeyInfo = rsaCryptoServiceProvider.ExportParameters(true);
+                var rsaSecurityKey = new RsaSecurityKey(rsaKeyInfo);
+
+                var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+
+                // Create the JWT and write it to a string
+                var jwtContents = new JwtSecurityToken(
+                    issuer: fakeIssuer,
+                    audience: fakeAudience,
+                    claims: claims,
+                    expires: DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(3)), // Default clock skew of 2 minutes
+                    signingCredentials: signingCredentials);
+                var jwt = new JwtSecurityTokenHandler().WriteToken(jwtContents);
+
+                var fakeOktaWebOptions = new OktaWebOptions
+                {
+                    OktaDomain = fakeIssuer,
+                };
+
+                var handler = new StrictTokenHandler();
+
+                var validationParameters = new DefaultTokenValidationParameters(fakeOktaWebOptions, fakeIssuer)
+                {
+                    IssuerSigningKey = signingCredentials.Key,
+                    ValidAudience = fakeAudience,
+                };
+
+                Action act = () => handler.ValidateToken(jwt, validationParameters, out _);
+
+                act.Should().Throw<SecurityTokenExpiredException>();
+            }
+        }
+
+        [Fact]
+        public void RejectUnsignedToken()
+        {
+            var fakeIssuer = "example.okta.com";
+            var fakeAudience = "aud://default";
+            var fakeClient = "fakeClient";
+
+            var claims = new Claim[]
+            {
+                new Claim("cid", fakeClient),
+            };
+
+            // Create the JWT and write it to a string
+            var jwtContents = new JwtSecurityToken(
+                issuer: fakeIssuer,
+                audience: fakeAudience,
+                claims: claims,
+                expires: DateTime.UtcNow.Add(TimeSpan.FromMinutes(1)));
+                // No signing credentials!
+
+            var jwt = new JwtSecurityTokenHandler().WriteToken(jwtContents);
+
+            var fakeOktaWebOptions = new OktaWebOptions
+            {
+                OktaDomain = fakeIssuer,
+            };
+
+            var handler = new StrictTokenHandler();
+
+            var validationParameters = new DefaultTokenValidationParameters(fakeOktaWebOptions, fakeIssuer)
+            {
+                ValidAudience = fakeAudience,
+            };
+
+            Action act = () => handler.ValidateToken(jwt, validationParameters, out _);
+
+            act.Should().Throw<SecurityTokenInvalidSignatureException>();
+        }
+
+        [Fact]
+        public void RejectWrongIssuer()
+        {
+            var fakeIssuer = "example.okta.com";
+            var fakeAudience = "aud://default";
+            var fakeClient = "fakeClient";
+
+            var claims = new Claim[]
+            {
+                new Claim("cid", fakeClient),
+            };
+
+            using (RSACryptoServiceProvider rsaCryptoServiceProvider = new RSACryptoServiceProvider(2048))
+            {
+                RSAParameters rsaKeyInfo = rsaCryptoServiceProvider.ExportParameters(true);
+                var rsaSecurityKey = new RsaSecurityKey(rsaKeyInfo);
+
+                var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+
+                // Create the JWT and write it to a string
+                var jwtContents = new JwtSecurityToken(
+                    issuer: "different-issuer",
+                    audience: fakeAudience,
+                    claims: claims,
+                    expires: DateTime.UtcNow.Add(TimeSpan.FromMinutes(1)),
+                    signingCredentials: signingCredentials);
+                var jwt = new JwtSecurityTokenHandler().WriteToken(jwtContents);
+
+                var fakeOktaWebOptions = new OktaWebOptions
+                {
+                    OktaDomain = fakeIssuer,
+                };
+
+                var handler = new StrictTokenHandler();
+
+                var validationParameters = new DefaultTokenValidationParameters(fakeOktaWebOptions, fakeIssuer)
+                {
+                    IssuerSigningKey = signingCredentials.Key,
+                    ValidAudience = fakeAudience,
+                };
+
+                Action act = () => handler.ValidateToken(jwt, validationParameters, out _);
+
+                act.Should().Throw<SecurityTokenInvalidIssuerException>();
+            }
+        }
+
+        [Fact]
+        public void RejectWrongAudience()
+        {
+            var fakeIssuer = "example.okta.com";
+            var fakeAudience = "aud://default";
+            var fakeClient = "fakeClient";
+
+            var claims = new Claim[]
+            {
+                new Claim("cid", fakeClient),
+            };
+
+            using (RSACryptoServiceProvider rsaCryptoServiceProvider = new RSACryptoServiceProvider(2048))
+            {
+                RSAParameters rsaKeyInfo = rsaCryptoServiceProvider.ExportParameters(true);
+                var rsaSecurityKey = new RsaSecurityKey(rsaKeyInfo);
+
+                var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+
+                // Create the JWT and write it to a string
+                var jwtContents = new JwtSecurityToken(
+                    issuer: fakeIssuer,
+                    audience: "http://myapi",
+                    claims: claims,
+                    expires: DateTime.UtcNow.Add(TimeSpan.FromMinutes(1)),
+                    signingCredentials: signingCredentials);
+                var jwt = new JwtSecurityTokenHandler().WriteToken(jwtContents);
+
+                var fakeOktaWebOptions = new OktaWebOptions
+                {
+                    OktaDomain = fakeIssuer,
+                };
+
+                var handler = new StrictTokenHandler();
+
+                var validationParameters = new DefaultTokenValidationParameters(fakeOktaWebOptions, fakeIssuer)
+                {
+                    IssuerSigningKey = signingCredentials.Key,
+                    ValidAudience = fakeAudience,
+                };
+
+                Action act = () => handler.ValidateToken(jwt, validationParameters, out _);
+
+                act.Should().Throw<SecurityTokenInvalidAudienceException>();
+            }
+        }
+    }
+}

--- a/Okta.AspNet.Abstractions.Test/TokenValidationShould.cs
+++ b/Okta.AspNet.Abstractions.Test/TokenValidationShould.cs
@@ -20,7 +20,6 @@ namespace Okta.AspNet.Abstractions.Test
         {
             var fakeIssuer = "example.okta.com";
             var fakeAudience = "aud://default";
-            var fakeClient = "fakeClient";
 
             var credentials = new SigningCredentials(
                 new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
@@ -76,7 +75,6 @@ namespace Okta.AspNet.Abstractions.Test
         {
             var fakeIssuer = "example.okta.com";
             var fakeAudience = "aud://default";
-            var fakeClient = "fakeClient";
 
             var credentials = new SigningCredentials(
                 new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
@@ -113,7 +111,6 @@ namespace Okta.AspNet.Abstractions.Test
         {
             var fakeIssuer = "example.okta.com";
             var fakeAudience = "aud://default";
-            var fakeClient = "fakeClient";
 
             // Create the JWT and write it to a string
             var jwtContents = new JwtSecurityToken(
@@ -145,7 +142,6 @@ namespace Okta.AspNet.Abstractions.Test
         {
             var fakeIssuer = "example.okta.com";
             var fakeAudience = "aud://default";
-            var fakeClient = "fakeClient";
 
             var credentials = new SigningCredentials(
                 new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
@@ -182,7 +178,6 @@ namespace Okta.AspNet.Abstractions.Test
         {
             var fakeIssuer = "example.okta.com";
             var fakeAudience = "aud://default";
-            var fakeClient = "fakeClient";
 
             var credentials = new SigningCredentials(
                 new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),

--- a/Okta.AspNet.Abstractions/StrictSecurityTokenValidator.cs
+++ b/Okta.AspNet.Abstractions/StrictSecurityTokenValidator.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="StrictSecurityTokenValidator.cs" company="Okta, Inc">
+// Copyright (c) 2018-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Okta.AspNet.Abstractions
+{
+    public sealed class StrictSecurityTokenValidator : ISecurityTokenValidator
+    {
+        private readonly JwtSecurityTokenHandler _handler;
+
+        public StrictSecurityTokenValidator(OktaWebOptions options)
+        {
+            _handler = new StrictTokenHandler();
+        }
+
+        public bool CanValidateToken => _handler.CanValidateToken;
+
+        public int MaximumTokenSizeInBytes
+        {
+            get => _handler.MaximumTokenSizeInBytes;
+            set => throw new NotImplementedException();
+        }
+
+        public bool CanReadToken(string securityToken) => _handler.CanReadToken(securityToken);
+
+        public ClaimsPrincipal ValidateToken(string securityToken, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
+            => _handler.ValidateToken(securityToken, validationParameters, out validatedToken);
+    }
+}

--- a/Okta.AspNet.Abstractions/StrictTokenHandler.cs
+++ b/Okta.AspNet.Abstractions/StrictTokenHandler.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="StrictTokenHandler.cs" company="Okta, Inc">
+// Copyright (c) 2018-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Okta.AspNet.Abstractions
+{
+    /// <summary>
+    /// This class performs additional validation per Okta's best practices.
+    /// https://developer.okta.com/code/dotnet/jwt-validation.
+    /// </summary>
+    public sealed class StrictTokenHandler : JwtSecurityTokenHandler
+    {
+        public StrictTokenHandler()
+        {
+        }
+
+        public override ClaimsPrincipal ValidateToken(string token, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
+        {
+            // base.ValidateToken will throw if the token is invalid
+            // in any way (according to validationParameters)
+            var claimsPrincipal = base.ValidateToken(token, validationParameters, out validatedToken);
+            var jwtToken = ReadJwtToken(token);
+
+            if (jwtToken.Header?.Alg == null || jwtToken.Header?.Alg != SecurityAlgorithms.RsaSha256)
+            {
+                throw new SecurityTokenValidationException("The alg must be RS256.");
+            }
+
+            return claimsPrincipal;
+        }
+    }
+}

--- a/Okta.AspNet/OktaMiddlewareExtensions.cs
+++ b/Okta.AspNet/OktaMiddlewareExtensions.cs
@@ -75,6 +75,7 @@ namespace Okta.AspNet
             {
                 AuthenticationMode = AuthenticationMode.Active,
                 TokenValidationParameters = tokenValidationParameters,
+                TokenHandler = new StrictTokenHandler(),
             });
         }
 
@@ -112,6 +113,7 @@ namespace Okta.AspNet
                 Scope = scopeString,
                 PostLogoutRedirectUri = options.PostLogoutRedirectUri,
                 TokenValidationParameters = tokenValidationParameters,
+                SecurityTokenValidator = new StrictSecurityTokenValidator(options),
                 Notifications = new OpenIdConnectAuthenticationNotifications
                 {
                     AuthorizationCodeReceived = tokenExchanger.ExchangeCodeForTokenAsync,

--- a/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
+++ b/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
@@ -45,6 +45,7 @@ namespace Okta.AspNetCore
                 oidcOptions.SignedOutCallbackPath = new PathString(OktaDefaults.SignOutCallbackPath);
                 oidcOptions.ResponseType = OpenIdConnectResponseType.Code;
                 oidcOptions.GetClaimsFromUserInfoEndpoint = options.GetClaimsFromUserInfoEndpoint;
+                oidcOptions.SecurityTokenValidator = new StrictSecurityTokenValidator(options);
                 oidcOptions.SaveTokens = true;
                 oidcOptions.UseTokenLifetime = false;
                 oidcOptions.BackchannelHttpHandler = new UserAgentHandler("okta-aspnetcore", typeof(OktaAuthenticationOptionsExtensions).Assembly.GetName().Version);
@@ -112,6 +113,9 @@ namespace Okta.AspNetCore
                 opt.Authority = issuer;
                 opt.TokenValidationParameters = tokenValidationParameters;
                 opt.BackchannelHttpHandler = new UserAgentHandler("okta-aspnetcore", typeof(OktaAuthenticationOptionsExtensions).Assembly.GetName().Version);
+
+                opt.SecurityTokenValidators.Clear();
+                opt.SecurityTokenValidators.Add(new StrictSecurityTokenValidator(options));
             });
 
             return builder;


### PR DESCRIPTION
As per our [JWT spec](https://github.com/okta/oss-technical-designs/blob/master/technical_designs/jwt-validation-libraries.md#access-token-verification) validate that `alg` claim is `RS256`.