### PR TITLE
Oidc Events OnTokenValidated endpoint exposed in OktaMvcOptions 

### DIFF
--- a/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
+++ b/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
@@ -67,6 +67,11 @@ namespace Okta.AspNetCore
                 };
 
                 oidcOptions.Events.OnRedirectToIdentityProvider = BeforeRedirectToIdentityProviderAsync;
+
+                if (options.OnTokenValidated != null)
+                {
+                    oidcOptions.Events.OnTokenValidated = options.OnTokenValidated;
+                }
             });
 
             return builder;

--- a/Okta.AspNetCore/OktaMvcOptions.cs
+++ b/Okta.AspNetCore/OktaMvcOptions.cs
@@ -3,7 +3,10 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace Okta.AspNetCore
 {
@@ -18,5 +21,7 @@ namespace Okta.AspNetCore
         public IList<string> Scope { get; set; } = OktaDefaults.Scope;
 
         public bool GetClaimsFromUserInfoEndpoint { get; set; } = false;
+
+        public Func<TokenValidatedContext, Task> OnTokenValidated { get; set; }
     }
 }


### PR DESCRIPTION
To be able to inject additional claims after authentication I externalize OnTokenValidated property into OktaMvcOptions class.

Below is an example of a possible utilization
```c#
services.AddAuthentication(options =>
                {
                    options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                    options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                    options.DefaultChallengeScheme = OktaDefaults.MvcAuthenticationScheme;
                })
                .AddCookie()
                .AddOktaMvc(new OktaMvcOptions
                {
                    OktaDomain = oktaConfig.Domain,
                    ClientId = oktaConfig.ClientId,
                    ClientSecret = oktaConfig.ClientSecret,
                    OnTokenValidated = async context =>
                    {
                       var oktaSub = context.Principal.FindFirstValue("sub");

                        // here we can insert some logic/db query to obtain required info from a local system

                        var claims = new List<Claim>
                        {
                            new Claim(ClaimTypes.Role, "superadmin")
                        };
                        
                        var appIdentity = new ClaimsIdentity(claims);

                        context.Principal.AddIdentity(appIdentity);
                    } 
                });
```