### PR TITLE
JwtBearerEvents config exposed in OktaWebApiOptions.

### DIFF
--- a/Okta.AspNet.Abstractions/OktaWebApiOptions.cs
+++ b/Okta.AspNet.Abstractions/OktaWebApiOptions.cs
@@ -15,5 +15,7 @@ namespace Okta.AspNet.Abstractions
 
         [Obsolete("ClientId is no longer required, and has no effect. This property will be removed in the next major release.")]
         public string ClientId { get; set; }
+
+        public JwtBearerEvents Events { get; set; }
     }
 }

--- a/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
+++ b/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
@@ -85,6 +85,8 @@ namespace Okta.AspNetCore
 
                 opt.SecurityTokenValidators.Clear();
                 opt.SecurityTokenValidators.Add(new StrictSecurityTokenValidator());
+
+                opt.Events = options.Events;
             });
 
             return builder;


### PR DESCRIPTION
Fixes #71 

This is needed to allow SignalR to work with Bearer tokens. Below is an example of how this could be used, influenced from https://docs.microsoft.com/en-us/aspnet/core/signalr/authn-and-authz?view=aspnetcore-2.2

```
services.AddAuthentication(options =>
            {
                options.DefaultAuthenticateScheme = OktaDefaults.ApiAuthenticationScheme;
                options.DefaultChallengeScheme = OktaDefaults.ApiAuthenticationScheme;
                options.DefaultSignInScheme = OktaDefaults.ApiAuthenticationScheme;
            })
            .AddOktaWebApi(new OktaWebApiOptions()
            {
                OktaDomain = Configuration["Authentication:Okta:OktaDomain"],
                AuthorizationServerId = Configuration["Authentication:Okta:AuthorizationServerId"],
                Audience = Configuration["Authentication:Okta:Audience"],

                // We have to hook the OnMessageReceived event in order to
                // allow the JWT authentication handler to read the access
                // token from the query string when a WebSocket or 
                // Server-Sent Events request comes in.
                Events = new JwtBearerEvents
                {
                    OnMessageReceived = context =>
                    {
                        var accessToken = context.Request.Query["access_token"];

                        // If the request is for our hub...
                        var path = context.HttpContext.Request.Path;
                        if (!string.IsNullOrEmpty(accessToken) &&
                            (path.StartsWithSegments("/hubs/chat")))
                        {
                        // Read the token out of the query string
                        context.Token = accessToken;
                        }
                        return Task.CompletedTask;
                    }
                }
            });
```