### PR TITLE
Add MSFT's NameIdentifier to support the .NET MVC antiforgery provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: csharp
 mono: latest
-dotnet: 2.1.3 # .NET Core
+sudo: required
+dist: xenial
+dotnet: 2.2 # .NET Core
 script:
   - ./build.sh
 

--- a/Okta.AspNet/TokenExchanger.cs
+++ b/Okta.AspNet/TokenExchanger.cs
@@ -54,6 +54,14 @@ namespace Okta.AspNet
                     tokenResponse).ConfigureAwait(false);
             }
 
+            // get subject claim and duplicate it to MSFT's NameIdentifier to support the .NET MVC antiforgery provider
+            var sub = response.AuthenticationTicket.Identity.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+            if (sub != null)
+            {
+                response.AuthenticationTicket.Identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, sub));
+                response.AuthenticationTicket.Identity.AddClaim(new Claim("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider", "ASP.NET Identity", "http://www.w3.org/2001/XMLSchema#string"));
+            }
+
             response.AuthenticationTicket.Identity.AddClaim(new Claim("id_token", tokenResponse.IdentityToken));
             response.AuthenticationTicket.Identity.AddClaim(new Claim("access_token", tokenResponse.AccessToken));
 


### PR DESCRIPTION
Fixes #64 

Following guidance at https://stackoverflow.com/a/32112517, duplicates the subject claim into MSFT's [NameIdentifier](http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier) to support the .NET MVC antiforgery provider.

This seems to be the best solution after deliberation with @nbarbettini.  Additional discussion can be found on [Jira](https://oktainc.atlassian.net/browse/OKTA-212374).