### PR TITLE
bump asp.net framework sdk to version 1.1.6 and fix up some metadata

### DIFF
--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <Description>Official Okta middleware for ASP.NET 4.5+. Easily add authentication and authorization to ASP.NET applications.</Description>
-    <Copyright>(c) 2018 Okta, Inc.</Copyright>
-    <VersionPrefix>1.1.5</VersionPrefix>
+    <Copyright>(c) 2019 Okta, Inc.</Copyright>
+    <VersionPrefix>1.1.6</VersionPrefix>
     <Authors>Okta, Inc.</Authors>
     <TargetFramework>net452</TargetFramework>
     <AssemblyName>Okta.AspNet</AssemblyName>
     <PackageId>Okta.AspNet</PackageId>
-    <PackageTags>okta,token,authentication,authorization</PackageTags>
+    <PackageTags>okta,token,authentication,authorization,oauth,sso,oidc</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/okta/okta-sdk-dotnet/master/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/okta/okta-aspnet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/okta/okta-aspnet/blob/master/LICENSE</PackageLicenseUrl>
@@ -29,6 +29,9 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
+    <AssemblyVersion>1.1.6.0</AssemblyVersion>
+    <FileVersion>1.1.6.0</FileVersion>
+    <Version>1.1.6</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <Description>Official Okta middleware for ASP.NET Core 2.0+. Easily add authentication and authorization to ASP.NET Core applications.</Description>
-    <Copyright>(c) 2018 Okta, Inc.</Copyright>
-    <VersionPrefix>1.1.5</VersionPrefix>
+    <Copyright>(c) 2019 Okta, Inc.</Copyright>
+    <VersionPrefix>1.1.6</VersionPrefix>
     <Authors>Okta, Inc.</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Okta.AspNetCore</AssemblyName>
     <PackageId>Okta.AspNetCore</PackageId>
-    <PackageTags>okta,token,authentication,authorization</PackageTags>
+    <PackageTags>okta,token,authentication,authorization,oauth,sso,oidc</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/okta/okta-sdk-dotnet/master/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/okta/okta-aspnet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/okta/okta-aspnet/blob/master/LICENSE</PackageLicenseUrl>
@@ -26,6 +26,9 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
+    <AssemblyVersion>1.1.6.0</AssemblyVersion>
+    <FileVersion>1.1.6.0</FileVersion>
+    <Version>1.1.6</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <Description>Official Okta middleware for ASP.NET Core 2.0+. Easily add authentication and authorization to ASP.NET Core applications.</Description>
-    <Copyright>(c) 2019 Okta, Inc.</Copyright>
-    <VersionPrefix>1.1.6</VersionPrefix>
+    <Copyright>(c) 2018 Okta, Inc.</Copyright>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <Authors>Okta, Inc.</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Okta.AspNetCore</AssemblyName>
     <PackageId>Okta.AspNetCore</PackageId>
-    <PackageTags>okta,token,authentication,authorization,oauth,sso,oidc</PackageTags>
+    <PackageTags>okta,token,authentication,authorization</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/okta/okta-sdk-dotnet/master/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/okta/okta-aspnet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/okta/okta-aspnet/blob/master/LICENSE</PackageLicenseUrl>
@@ -26,9 +26,6 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>1.1.6.0</AssemblyVersion>
-    <FileVersion>1.1.6.0</FileVersion>
-    <Version>1.1.6</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Fixes #64

[OKTA-230105]
Publish patch release for ASP.net SDK with new AntiForgeryToken code

Duplicates the subject claim into MSFT's NameIdentifier to support the .NET MVC antiforgery provider.