### PR TITLE
Expose Token events so users can add custom claims

### DIFF
--- a/Okta.AspNet.Abstractions/OktaWebOptions.cs
+++ b/Okta.AspNet.Abstractions/OktaWebOptions.cs
@@ -13,10 +13,28 @@ namespace Okta.AspNet.Abstractions
 
         public static readonly TimeSpan DefaultClockSkew = TimeSpan.FromMinutes(2);
 
+        /// <summary>
+        /// Gets or sets the Okta domain, i.e https://dev-123456.oktapreview.com.
+        /// </summary>
+        /// <value>
+        /// The Okta domain.
+        /// </value>
         public string OktaDomain { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Okta Authorization Server to use. The default value is default.
+        /// </summary>
+        /// <value>
+        /// The Okta Authorization Server.
+        /// </value>
         public string AuthorizationServerId { get; set; } = DefaultAuthorizationServerId;
 
+        /// <summary>
+        /// Gets or sets the clock skew allowed when validating tokens. The default value is 2 minutes.
+        /// </summary>
+        /// <value>
+        /// The clock skew.
+        /// </value>
         public TimeSpan ClockSkew { get; set; } = DefaultClockSkew;
     }
 }

--- a/Okta.AspNet.Abstractions/OktaWebOptions.cs
+++ b/Okta.AspNet.Abstractions/OktaWebOptions.cs
@@ -22,7 +22,7 @@ namespace Okta.AspNet.Abstractions
         public string OktaDomain { get; set; }
 
         /// <summary>
-        /// Gets or sets the Okta Authorization Server to use. The default value is default.
+        /// Gets or sets the Okta Authorization Server to use. The default value is <c>default</c>.
         /// </summary>
         /// <value>
         /// The Okta Authorization Server.

--- a/Okta.AspNet.Test/Okta.AspNet.Test.csproj
+++ b/Okta.AspNet.Test/Okta.AspNet.Test.csproj
@@ -10,6 +10,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <ProjectReference Include="..\Okta.AspNet\Okta.AspNet.csproj" />

--- a/Okta.AspNet.Test/OpenIdConnectAuthenticationOptionsBuilderShould.cs
+++ b/Okta.AspNet.Test/OpenIdConnectAuthenticationOptionsBuilderShould.cs
@@ -3,9 +3,14 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin.Security.Notifications;
 using Microsoft.Owin.Security.OpenIdConnect;
+using NSubstitute;
 using Okta.AspNet.Abstractions;
 using Xunit;
 
@@ -16,6 +21,8 @@ namespace Okta.AspNet.Test
         [Fact]
         public void BuildOpenIdConnectAuthenticationOptionsCorrectly()
         {
+            var mockTokenEvent = Substitute.For<Func<SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task>>();
+
             var oktaMvcOptions = new OktaMvcOptions()
             {
                 PostLogoutRedirectUri = "http://postlogout.com",
@@ -24,6 +31,7 @@ namespace Okta.AspNet.Test
                 ClientSecret = "bar",
                 RedirectUri = "/redirectUri",
                 Scope = new List<string> { "openid", "profile", "email" },
+                SecurityTokenValidated = mockTokenEvent,
             };
 
             var notifications = new OpenIdConnectAuthenticationNotifications
@@ -43,6 +51,10 @@ namespace Okta.AspNet.Test
             oidcOptions.Authority.Should().Be(issuer);
             oidcOptions.RedirectUri.Should().Be(oktaMvcOptions.RedirectUri);
             oidcOptions.Scope.Should().Be(string.Join(" ", oktaMvcOptions.Scope));
+
+            // Check the event was call once with a null parameter
+            oidcOptions.Notifications.SecurityTokenValidated(null);
+            mockTokenEvent.Received(1).Invoke(null);
         }
     }
 }

--- a/Okta.AspNet/OktaMvcOptions.cs
+++ b/Okta.AspNet/OktaMvcOptions.cs
@@ -51,10 +51,6 @@ namespace Okta.AspNet
         /// Gets or sets the event invoked after the security token has passed validation and a ClaimsIdentity has been generated.
         /// </summary>
         /// <value>The SecurityTokenValidated event.</value>
-        public Func<SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> SecurityTokenValidated
-        {
-            get;
-            set;
-        }
+        public Func<SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> SecurityTokenValidated { get; set; } = notification => Task.FromResult(0);
     }
 }

--- a/Okta.AspNet/OktaMvcOptions.cs
+++ b/Okta.AspNet/OktaMvcOptions.cs
@@ -3,22 +3,58 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin.Security.Notifications;
+using Microsoft.Owin.Security.OpenIdConnect;
 
 namespace Okta.AspNet
 {
     public class OktaMvcOptions : Abstractions.OktaWebOptions
     {
+        /// <summary>
+        /// Gets or sets the client secret of your Okta Application.
+        /// </summary>
+        /// <value>The client secret.</value>
         public string ClientSecret { get; set; }
 
+        /// <summary>
+        /// Gets or sets the client ID of your Okta Application.
+        /// </summary>
+        /// <value>The client ID.</value>
         public string ClientId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the location Okta should redirect to process a login.
+        /// </summary>
+        /// <value>The redirect uri.</value>
         public string RedirectUri { get; set; }
 
+        /// <summary>
+        /// Gets or sets the location Okta should redirect to after logout. If blank, Okta will redirect to the Okta login page.
+        /// </summary>
+        /// <value>The post-logout redirect URI.</value>
         public string PostLogoutRedirectUri { get; set; }
 
+        /// <summary>
+        /// Gets or sets the OAuth 2.0/OpenID Connect scopes to request when logging in.
+        /// </summary>
+        /// <value>The scope.</value>
         public IList<string> Scope { get; set; } = OktaDefaults.Scope;
 
+        [Obsolete("This property has been deprecated and it will be no longer supported.", false)]
         public bool GetClaimsFromUserInfoEndpoint { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the event invoked after the security token has passed validation and a ClaimsIdentity has been generated.
+        /// </summary>
+        /// <value>The SecurityTokenValidated event.</value>
+        public Func<SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> SecurityTokenValidated
+        {
+            get;
+            set;
+        }
     }
 }

--- a/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
+++ b/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
@@ -40,7 +40,7 @@ namespace Okta.AspNet
             var definedScopes = oktaMvcOptions.Scope?.ToArray() ?? OktaDefaults.Scope;
             var scopeString = string.Join(" ", definedScopes);
 
-            return new OpenIdConnectAuthenticationOptions
+            var oidcOptions = new OpenIdConnectAuthenticationOptions
             {
                 ClientId = oktaMvcOptions.ClientId,
                 ClientSecret = oktaMvcOptions.ClientSecret,
@@ -57,6 +57,13 @@ namespace Okta.AspNet
                     RedirectToIdentityProvider = notifications.RedirectToIdentityProvider,
                 },
             };
+
+            if (oktaMvcOptions.SecurityTokenValidated != null)
+            {
+                oidcOptions.Notifications.SecurityTokenValidated = oktaMvcOptions.SecurityTokenValidated;
+            }
+
+            return oidcOptions;
         }
     }
 }

--- a/Okta.AspNetCore.Test/Okta.AspNetCore.Test.csproj
+++ b/Okta.AspNetCore.Test/Okta.AspNetCore.Test.csproj
@@ -10,6 +10,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <ProjectReference Include="..\Okta.AspNetCore\Okta.AspNetCore.csproj" />

--- a/Okta.AspNetCore.Test/OpenIdConnectOptionsHelperShould.cs
+++ b/Okta.AspNetCore.Test/OpenIdConnectOptionsHelperShould.cs
@@ -62,9 +62,13 @@ namespace Okta.AspNetCore.Test
             oidcOptions.Events.OnTokenValidated(null);
             mockTokenValidatedEvent.Received(1).Invoke(null);
 
-            // Check the event was call once with a null parameter
-            oidcOptions.Events.OnUserInformationReceived(null);
-            mockUserInfoReceivedEvent.Received(1).Invoke(null);
+            // UserInfo event is mapped only when GetClaimsFromUserInfoEndpoint = true
+            if (oidcOptions.GetClaimsFromUserInfoEndpoint)
+            {
+                // Check the event was call once with a null parameter
+                oidcOptions.Events.OnUserInformationReceived(null);
+                mockUserInfoReceivedEvent.Received(1).Invoke(null);
+            }
         }
     }
 }

--- a/Okta.AspNetCore/OktaMvcOptions.cs
+++ b/Okta.AspNetCore/OktaMvcOptions.cs
@@ -3,22 +3,61 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace Okta.AspNetCore
 {
     public class OktaMvcOptions : AspNet.Abstractions.OktaWebOptions
     {
+        /// <summary>
+        /// Gets or sets the client secret of your Okta Application.
+        /// </summary>
+        /// <value>The client secret.</value>
         public string ClientSecret { get; set; }
 
+        /// <summary>
+        /// Gets or sets the client ID of your Okta Application.
+        /// </summary>
+        /// <value>The client ID.</value>
         public string ClientId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the location Okta should redirect to process a login.
+        /// </summary>
+        /// <value>The callback path.</value>
         public string CallbackPath { get; set; } = OktaDefaults.CallbackPath;
 
+        /// <summary>
+        /// Gets or sets the location Okta should redirect to after logout. If blank, Okta will redirect to the Okta login page.
+        /// </summary>
+        /// <value>The post-logout redirect URI.</value>
         public string PostLogoutRedirectUri { get; set; }
 
+        /// <summary>
+        /// Gets or sets the OAuth 2.0/OpenID Connect scopes to request when logging in.
+        /// </summary>
+        /// <value>The scope.</value>
         public IList<string> Scope { get; set; } = OktaDefaults.Scope;
 
-        public bool GetClaimsFromUserInfoEndpoint { get; set; } = false;
+        /// <summary>
+        /// Gets or sets a value indicating whether to retrieve additional claims from the UserInfo endpoint after login.
+        /// </summary>
+        /// <value>The GetClaimsFromUserInfoEndpoint flag.</value>
+        public bool GetClaimsFromUserInfoEndpoint { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the event invoked when an IdToken has been validated and produced an AuthenticationTicket.
+        /// </summary>
+        /// <value>The OnTokenValidated event.</value>
+        public Func<TokenValidatedContext, Task> OnTokenValidated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the event invoked when user information is retrieved from the UserInfoEndpoint. The <see cref="GetClaimsFromUserInfoEndpoint"/> value must be true when using this event.
+        /// </summary>
+        /// <value>The OnUserInformationReceived event.</value>
+        public Func<UserInformationReceivedContext, Task> OnUserInformationReceived { get; set; }
     }
 }

--- a/Okta.AspNetCore/OktaMvcOptions.cs
+++ b/Okta.AspNetCore/OktaMvcOptions.cs
@@ -52,12 +52,12 @@ namespace Okta.AspNetCore
         /// Gets or sets the event invoked when an IdToken has been validated and produced an AuthenticationTicket.
         /// </summary>
         /// <value>The OnTokenValidated event.</value>
-        public Func<TokenValidatedContext, Task> OnTokenValidated { get; set; }
+        public Func<TokenValidatedContext, Task> OnTokenValidated { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
         /// Gets or sets the event invoked when user information is retrieved from the UserInfoEndpoint. The <see cref="GetClaimsFromUserInfoEndpoint"/> value must be true when using this event.
         /// </summary>
         /// <value>The OnUserInformationReceived event.</value>
-        public Func<UserInformationReceivedContext, Task> OnUserInformationReceived { get; set; }
+        public Func<UserInformationReceivedContext, Task> OnUserInformationReceived { get; set; } = context => Task.CompletedTask;
     }
 }

--- a/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
+++ b/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Linq;
+using Microsoft.AspNetCore.Authentication.OAuth.Claims;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -55,6 +56,21 @@ namespace Okta.AspNetCore
             };
 
             oidcOptions.Events.OnRedirectToIdentityProvider = events.OnRedirectToIdentityProvider;
+
+            if (oktaMvcOptions.OnTokenValidated != null)
+            {
+                oidcOptions.Events.OnTokenValidated = oktaMvcOptions.OnTokenValidated;
+            }
+
+            if (oktaMvcOptions.GetClaimsFromUserInfoEndpoint && oktaMvcOptions.OnUserInformationReceived != null)
+            {
+                oidcOptions.Events.OnUserInformationReceived = oktaMvcOptions.OnUserInformationReceived;
+            }
+
+            if (oktaMvcOptions.GetClaimsFromUserInfoEndpoint)
+            {
+                oidcOptions.ClaimActions.Add(new MapAllClaimsAction());
+            }
         }
     }
 }


### PR DESCRIPTION
Expose Token/UserInfo events in Asp.Net Core. 
By default, we're getting claims from the UserInfo endpoint and mapping all of them to the principal.

Expose Token event in Asp.Net. UserInfo event is not available since is not part of project Katana. 
Since Asp.Net is using the hybrid flow, all the Okta custom claims configured as Always/IdToken/UserInfo come as part of the "Hybrid Id Token" regardless the `GetClaimsFromUserInfoEndpoint` configuration. That's why `GetClaimsFromUserInfoEndpoint` is gonna be marked as `Obsolete`, and the method `EnrichIdentityViaUserInfoAsync` is gonna be removed to avoid confusion.
If devs want to get any additional user information they can still use the management SDK.

