### PR TITLE
Add LoginMode property in OktaMvcOptions 

### DIFF
--- a/Okta.AspNet/LoginMode.cs
+++ b/Okta.AspNet/LoginMode.cs
@@ -5,9 +5,9 @@
 
 namespace Okta.AspNet
 {
-     /// <summary>
-     /// LoginMode controls the behavior of the middleware.
-     /// </summary>
+    /// <summary>
+    /// LoginMode controls the login redirect behavior of the middleware.
+    /// </summary>
     public enum LoginMode
     {
         /// <summary>

--- a/Okta.AspNet/LoginMode.cs
+++ b/Okta.AspNet/LoginMode.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="LoginMode.cs" company="Okta, Inc">
+// Copyright (c) 2018-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Okta.AspNet
+{
+     /// <summary>
+     /// LoginMode controls the behavior of the middleware.
+     /// </summary>
+    public enum LoginMode
+    {
+        /// <summary>
+        /// Indicates that the login page will be provided and hosted by Okta.
+        /// </summary>
+        OktaHosted,
+
+        /// <summary>
+        /// Indicates that a self-hosted login page will be provider by the user.
+        /// </summary>
+        SelfHosted,
+    }
+}

--- a/Okta.AspNet/OktaMvcOptions.cs
+++ b/Okta.AspNet/OktaMvcOptions.cs
@@ -45,7 +45,7 @@ namespace Okta.AspNet
         public IList<string> Scope { get; set; } = OktaDefaults.Scope;
 
         /// <summary>
-        /// Gets or sets the <see cref="LoginMode"/>.
+        /// Gets or sets the <see cref="LoginMode"/> to control the login redirect behavior of the middleware.
         /// </summary>
         /// <value>The login mode.</value>
         public LoginMode LoginMode { get; set; } = LoginMode.OktaHosted;

--- a/Okta.AspNet/OktaMvcOptions.cs
+++ b/Okta.AspNet/OktaMvcOptions.cs
@@ -44,6 +44,12 @@ namespace Okta.AspNet
         /// <value>The scope.</value>
         public IList<string> Scope { get; set; } = OktaDefaults.Scope;
 
+        /// <summary>
+        /// Gets or sets the <see cref="LoginMode"/>.
+        /// </summary>
+        /// <value>The login mode.</value>
+        public LoginMode LoginMode { get; set; } = LoginMode.OktaHosted;
+
         [Obsolete("This property has been deprecated and it will be no longer supported.", false)]
         public bool GetClaimsFromUserInfoEndpoint { get; set; } = false;
 

--- a/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
+++ b/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.OpenIdConnect;
 using Okta.AspNet.Abstractions;
 
@@ -51,6 +52,7 @@ namespace Okta.AspNet
                 PostLogoutRedirectUri = oktaMvcOptions.PostLogoutRedirectUri,
                 TokenValidationParameters = tokenValidationParameters,
                 SecurityTokenValidator = new StrictSecurityTokenValidator(),
+                AuthenticationMode = (oktaMvcOptions.LoginMode == LoginMode.SelfHosted) ? AuthenticationMode.Passive : AuthenticationMode.Active,
                 Notifications = new OpenIdConnectAuthenticationNotifications
                 {
                     AuthorizationCodeReceived = tokenExchanger.ExchangeCodeForTokenAsync,

--- a/docs/aspnet4x-mvc.md
+++ b/docs/aspnet4x-mvc.md
@@ -12,7 +12,14 @@ Or, you can use the `dotnet` command:
 ```
 dotnet add package Okta.AspNet
 ```
-# Usage example
+# Usage guide
+
+These examples will help you to understand how to use this library. You can also check out our ASP.NET samples:
+
+* [ASP.NET MVC Samples](https://github.com/okta/samples-aspnet)
+* [ASP.NET Web Forms Samples](https://github.com/okta/samples-aspnet-webforms)
+
+## Basic configuration
 
 Okta plugs into your OWIN Startup class with the `UseOktaMvc()` method:
 
@@ -36,11 +43,40 @@ public class Startup
     }
 }
 ```
-## That's it!
+### That's it!
 
 Placing the `[Authorize]` attribute on your controllers or actions will check whether the user is logged in, and redirect them to Okta if necessary.
 
 ASP.NET automatically populates `HttpContext.User` with the information Okta sends back about the user. You can check whether the user is logged in with `User.Identity.IsAuthenticated` in your actions or views.
+
+## Self-Hosted login configuration
+
+```csharp
+public class Startup
+{
+    public void Configuration(IAppBuilder app)
+    {
+        app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
+        app.UseCookieAuthentication(new CookieAuthenticationOptions()
+            {
+                LoginPath = new PathString("/Account/Login"),
+            });
+
+        app.UseOktaMvc(new OktaMvcOptions
+        {
+            OktaDomain = "https://{yourOktaDomain}",
+            ClientId = "{clientId}",
+            ClientSecret = "{clientSecret}",
+            AuthorizationServerId = "default",
+            RedirectUri = "http://localhost:8080/authorization-code/callback",
+            PostLogoutRedirectUri = "http://localhost:8080/Home",
+            LoginMode = LoginMode.SelfHosted
+        });
+    }
+}
+```
+
+> Note: If you are using role-based authorization and you need to redirect not-authorized users to an access-denied page or similar, check out [CookieAuthenticationProvider.ApplyRedirect](https://docs.microsoft.com/en-us/previous-versions/aspnet/mt152260(v%3Dvs.113)).
 
 # Configuration Reference
 
@@ -56,6 +92,7 @@ The `OktaMvcOptions` class configures the Okta middleware. You can see all the a
 | AuthorizationServerId     | No           | The Okta Authorization Server to use. The default value is `default`. |
 | PostLogoutRedirectUri     | No           | The location Okta should redirect to after logout. If blank, Okta will redirect to the Okta login page. |
 | Scope                     | No           | The OAuth 2.0/OpenID Connect scopes to request when logging in. The default value is `openid profile`. |
+| LoginMode                     | No           | LoginMode controls the login redirect behavior of the middleware. The default value is `OktaHosted`. |
 | GetClaimsFromUserInfoEndpoint | No       | This property has been deprecated and will be no longer supported. |
 | ClockSkew                 | No           | The clock skew allowed when validating tokens. The default value is 2 minutes. |
 | SecurityTokenValidated                 | No           | The event invoked after the security token has passed validation and a `ClaimsIdentity` has been generated. |


### PR DESCRIPTION
Fixes #77 

This property is only available on ASP.NET since ASP.NET Core already has a workaround: https://github.com/okta/samples-aspnetcore/pull/27.

