### PR TITLE
Update configuration reference.

### DIFF
--- a/docs/aspnetcore-mvc.md
+++ b/docs/aspnetcore-mvc.md
@@ -113,7 +113,7 @@ The `OktaMvcOptions` class configures the Okta middleware. You can see all the a
 | OktaDomain                    | **Yes**      | Your Okta domain, i.e https://dev-123456.oktapreview.com  | 
 | ClientId                  | **Yes**      | The client ID of your Okta Application |
 | ClientSecret              | **Yes**      | The client secret of your Okta Application |
-| RedirectUri               | **Yes**      | The location Okta should redirect to process a login. This is typically `http://{yourApp}/authorization-code/callback`. No matter the value, the redirect is handled automatically by this package, so you don't need to write any custom code to handle this route. |
+| CallbackPath               | **Yes**      | The location Okta should redirect to process a login. This is typically `http://{yourApp}/authorization-code/callback`. No matter the value, the redirect is handled automatically by this package, so you don't need to write any custom code to handle this route. |
 | AuthorizationServerId     | No           | The Okta Authorization Server to use. The default value is `default`. |
 | PostLogoutRedirectUri     | No           | The location Okta should redirect to after logout. If blank, Okta will redirect to the Okta login page. |
 | Scope                     | No           | The OAuth 2.0/OpenID Connect scopes to request when logging in. The default value is `openid profile`. |


### PR DESCRIPTION
In ASP.NET Core to configure the redirect URI you have to set the `CallbackPath`. I've updated the configuration reference to reflect this.