### PR TITLE
Add support for Web Proxy when communicating with Okta Domain

### DIFF
--- a/Okta.AspNet.Abstractions/OktaWebOptions.cs
+++ b/Okta.AspNet.Abstractions/OktaWebOptions.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Net.Http;
 
 namespace Okta.AspNet.Abstractions
 {
@@ -20,6 +21,12 @@ namespace Okta.AspNet.Abstractions
         /// The Okta domain.
         /// </value>
         public string OktaDomain { get; set; }
+
+        /// <summary>
+        /// Gets or sets the BackchannelHttpHandler to be used when communicating with the Okta Domain.
+        /// </summary>
+        /// <value>The BackchannelHttpHandler.</value>
+        public HttpMessageHandler BackchannelHttpHandler { get; set; } = new HttpClientHandler();
 
         /// <summary>
         /// Gets or sets the Okta Authorization Server to use. The default value is <c>default</c>.

--- a/Okta.AspNet.Abstractions/OktaWebOptionsValidator.cs
+++ b/Okta.AspNet.Abstractions/OktaWebOptionsValidator.cs
@@ -57,6 +57,12 @@ namespace Okta.AspNet.Abstractions
                     $"It looks like there's a typo in your Okta domain. Current value: {options.OktaDomain}. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain", nameof(options.OktaDomain));
             }
 
+            if (options.BackchannelHttpHandler == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(options.BackchannelHttpHandler));
+            }
+
             ValidateInternal((T)options);
         }
     }

--- a/Okta.AspNet/OktaMvcOptions.cs
+++ b/Okta.AspNet/OktaMvcOptions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Owin.Security.Notifications;
@@ -61,5 +62,11 @@ namespace Okta.AspNet
         /// </summary>
         /// <value>The SecurityTokenValidated event.</value>
         public Func<SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> SecurityTokenValidated { get; set; } = notification => Task.FromResult(0);
+
+        /// <summary>
+        /// Gets or sets the BackchannelHttpHandler to be used when communicating with the Okta Endpoint.
+        /// </summary>
+        /// <value>The BackchannelHttpHandler.</value>
+        public HttpMessageHandler BackchannelHttpHandler { get; set; } = new HttpClientHandler();
     }
 }

--- a/Okta.AspNet/OktaMvcOptionsValidator.cs
+++ b/Okta.AspNet/OktaMvcOptionsValidator.cs
@@ -46,6 +46,13 @@ namespace Okta.AspNet
                     nameof(options.RedirectUri),
                     "Your Okta Application redirect URI is missing. You can find it in the Okta Developer Console in the details for the Application you created.");
             }
+
+            if (options.BackchannelHttpHandler == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(options.BackchannelHttpHandler),
+                    "The BackchannelHttpHandler must be set");
+            }
         }
     }
 }

--- a/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
+++ b/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
@@ -28,7 +28,10 @@ namespace Okta.AspNet
         {
             _oktaMvcOptions = oktaMvcOptions;
             _issuer = UrlHelper.CreateIssuerUrl(oktaMvcOptions.OktaDomain, oktaMvcOptions.AuthorizationServerId);
-            _httpClient = new HttpClient(new UserAgentHandler("okta-aspnet", typeof(OktaMiddlewareExtensions).Assembly.GetName().Version));
+            _httpClient = new HttpClient(new UserAgentHandler("okta-aspnet", typeof(OktaMiddlewareExtensions).Assembly.GetName().Version)
+            {
+                InnerHandler = oktaMvcOptions.BackchannelHttpHandler,
+            });
             _configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                     _issuer + "/.well-known/openid-configuration",
                     new OpenIdConnectConfigurationRetriever(),

--- a/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
+++ b/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
@@ -104,7 +104,10 @@ namespace Okta.AspNetCore
                 opt.Audience = options.Audience;
                 opt.Authority = issuer;
                 opt.TokenValidationParameters = tokenValidationParameters;
-                opt.BackchannelHttpHandler = new UserAgentHandler("okta-aspnetcore", typeof(OktaAuthenticationOptionsExtensions).Assembly.GetName().Version);
+                opt.BackchannelHttpHandler = new UserAgentHandler("okta-aspnetcore", typeof(OktaAuthenticationOptionsExtensions).Assembly.GetName().Version)
+                {
+                    InnerHandler = options.BackchannelHttpHandler,
+                };
 
                 opt.SecurityTokenValidators.Clear();
                 opt.SecurityTokenValidators.Add(new StrictSecurityTokenValidator());

--- a/Okta.AspNetCore/OktaMvcOptions.cs
+++ b/Okta.AspNetCore/OktaMvcOptions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -59,5 +60,11 @@ namespace Okta.AspNetCore
         /// </summary>
         /// <value>The OnUserInformationReceived event.</value>
         public Func<UserInformationReceivedContext, Task> OnUserInformationReceived { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
+        /// Gets or sets the BackchannelHttpHandler to be used when communicating with the Okta Domain.
+        /// </summary>
+        /// <value>The BackchannelHttpHandler.</value>
+        public HttpMessageHandler BackchannelHttpHandler { get; set; } = new HttpClientHandler();
     }
 }

--- a/Okta.AspNetCore/OktaMvcOptionsValidator.cs
+++ b/Okta.AspNetCore/OktaMvcOptionsValidator.cs
@@ -52,6 +52,12 @@ namespace Okta.AspNetCore
                     nameof(options.CallbackPath),
                     "Your Okta Application callback path is missing. It should match the path of the redirect URI you specified in the Okta Developer Console for this application.");
             }
+
+            if (options.BackchannelHttpHandler == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(options.BackchannelHttpHandler));
+            }
         }
     }
 }

--- a/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
+++ b/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
@@ -40,7 +40,10 @@ namespace Okta.AspNetCore
             oidcOptions.UseTokenLifetime = false;
             oidcOptions.BackchannelHttpHandler = new UserAgentHandler(
                 "okta-aspnetcore",
-                typeof(OktaAuthenticationOptionsExtensions).Assembly.GetName().Version);
+                typeof(OktaAuthenticationOptionsExtensions).Assembly.GetName().Version)
+            {
+                InnerHandler = oktaMvcOptions.BackchannelHttpHandler,
+            };
 
             var hasDefinedScopes = oktaMvcOptions.Scope?.Any() ?? false;
             if (hasDefinedScopes)


### PR DESCRIPTION
## Current behavior
It is not easy to configure the use of a web proxy for communication with the Okta Domain.  When deploying an application in an environment when there is no open outbound internet access, apart from through a (optionally authenticated) web proxy - a mechanism is needed to configure the use of that proxy in the Okta client code.

## Desired behavior
This PR would allow for the optional configuration of the BackchannelHttpHandler.

For example:

```c#
oktaMvcOptions.BackchannelHttpHandler = new HttpClientHandler
{
	UseProxy = true,
	Proxy = new WebProxy
	{
		Address = new Uri(config["HttpProxy"])
	}
};
```

## Additional Context
We can only currently achieve this by copying and modifying parts of the `OktaAuthenticationOptionsExtensions` - it would be very helpful to have explicit support for this

