### PR TITLE
OKTA-296007: expose failure related events; AspNet and AspNetCore

### DIFF
--- a/Okta.AspNet/OktaMvcOptions.cs
+++ b/Okta.AspNet/OktaMvcOptions.cs
@@ -61,5 +61,10 @@ namespace Okta.AspNet
         /// </summary>
         /// <value>The SecurityTokenValidated event.</value>
         public Func<SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> SecurityTokenValidated { get; set; } = notification => Task.FromResult(0);
+
+        /// <summary>
+        /// Gets or sets the event invoked if exceptions are thrown during request processing.
+        /// </summary>
+        public Func<AuthenticationFailedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> AuthenticationFailed { get; set; } = notification => Task.FromResult(0);
     }
 }

--- a/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
+++ b/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
@@ -72,6 +72,7 @@ namespace Okta.AspNet
                 {
                     RedirectToIdentityProvider = BeforeRedirectToIdentityProviderAsync,
                     SecurityTokenValidated = SecurityTokenValidatedAsync,
+                    AuthenticationFailed = _oktaMvcOptions.AuthenticationFailed,
                 },
             };
 

--- a/Okta.AspNetCore.Test/OpenIdConnectOptionsHelperShould.cs
+++ b/Okta.AspNetCore.Test/OpenIdConnectOptionsHelperShould.cs
@@ -41,7 +41,7 @@ namespace Okta.AspNetCore.Test
                 OnTokenValidated = mockTokenValidatedEvent,
                 OnUserInformationReceived = mockUserInfoReceivedEvent,
                 OnAuthenticationFailed = mockAuthenticationFailedEvent,
-                OnOktaException = mockOktaExceptionEvent,
+                OnOktaApiFailure = mockOktaExceptionEvent,
             };
 
             var events = new OpenIdConnectEvents() { OnRedirectToIdentityProvider = null };

--- a/Okta.AspNetCore.Test/OpenIdConnectOptionsHelperShould.cs
+++ b/Okta.AspNetCore.Test/OpenIdConnectOptionsHelperShould.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using NSubstitute;
 using Okta.AspNet.Abstractions;
@@ -24,6 +25,8 @@ namespace Okta.AspNetCore.Test
         {
             var mockTokenValidatedEvent = Substitute.For<Func<TokenValidatedContext, Task>>();
             var mockUserInfoReceivedEvent = Substitute.For<Func<UserInformationReceivedContext, Task>>();
+            var mockOktaExceptionEvent = Substitute.For<Func<RemoteFailureContext, Task>>();
+            var mockAuthenticationFailedEvent = Substitute.For<Func<AuthenticationFailedContext, Task>>();
 
             var oktaMvcOptions = new OktaMvcOptions
             {
@@ -37,6 +40,8 @@ namespace Okta.AspNetCore.Test
                 Scope = new List<string> { "openid", "profile", "email" },
                 OnTokenValidated = mockTokenValidatedEvent,
                 OnUserInformationReceived = mockUserInfoReceivedEvent,
+                OnAuthenticationFailed = mockAuthenticationFailedEvent,
+                OnOktaException = mockOktaExceptionEvent,
             };
 
             var events = new OpenIdConnectEvents() { OnRedirectToIdentityProvider = null };
@@ -61,6 +66,10 @@ namespace Okta.AspNetCore.Test
             // Check the event was call once with a null parameter
             oidcOptions.Events.OnTokenValidated(null);
             mockTokenValidatedEvent.Received(1).Invoke(null);
+            oidcOptions.Events.OnAuthenticationFailed(null);
+            mockAuthenticationFailedEvent.Received(1).Invoke(null);
+            oidcOptions.Events.OnRemoteFailure(null);
+            mockOktaExceptionEvent.Received(1).Invoke(null);
 
             // UserInfo event is mapped only when GetClaimsFromUserInfoEndpoint = true
             if (oidcOptions.GetClaimsFromUserInfoEndpoint)

--- a/Okta.AspNetCore/OktaMvcOptions.cs
+++ b/Okta.AspNetCore/OktaMvcOptions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace Okta.AspNetCore
@@ -59,5 +60,15 @@ namespace Okta.AspNetCore
         /// </summary>
         /// <value>The OnUserInformationReceived event.</value>
         public Func<UserInformationReceivedContext, Task> OnUserInformationReceived { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
+        /// Gets or sets the event invoked when a failure occurs within the Okta api.
+        /// </summary>
+        public Func<RemoteFailureContext, Task> OnOktaException { get; set; } = context => Task.CompletedTask;
+
+        /// <summary>
+        /// Gets or sets the event invoked if exceptions are thrown during request processing.
+        /// </summary>
+        public Func<AuthenticationFailedContext, Task> OnAuthenticationFailed { get; set; } = context => Task.CompletedTask;
     }
 }

--- a/Okta.AspNetCore/OktaMvcOptions.cs
+++ b/Okta.AspNetCore/OktaMvcOptions.cs
@@ -64,7 +64,7 @@ namespace Okta.AspNetCore
         /// <summary>
         /// Gets or sets the event invoked when a failure occurs within the Okta api.
         /// </summary>
-        public Func<RemoteFailureContext, Task> OnOktaException { get; set; } = context => Task.CompletedTask;
+        public Func<RemoteFailureContext, Task> OnOktaApiFailure { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
         /// Gets or sets the event invoked if exceptions are thrown during request processing.

--- a/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
+++ b/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
@@ -74,6 +74,16 @@ namespace Okta.AspNetCore
             {
                 oidcOptions.ClaimActions.Add(new MapAllClaimsAction());
             }
+
+            if (oktaMvcOptions.OnOktaException != null)
+            {
+                oidcOptions.Events.OnRemoteFailure = oktaMvcOptions.OnOktaException;
+            }
+
+            if (oktaMvcOptions.OnAuthenticationFailed != null)
+            {
+                oidcOptions.Events.OnAuthenticationFailed = oktaMvcOptions.OnAuthenticationFailed;
+            }
         }
     }
 }

--- a/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
+++ b/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
@@ -75,9 +75,9 @@ namespace Okta.AspNetCore
                 oidcOptions.ClaimActions.Add(new MapAllClaimsAction());
             }
 
-            if (oktaMvcOptions.OnOktaException != null)
+            if (oktaMvcOptions.OnOktaApiFailure != null)
             {
-                oidcOptions.Events.OnRemoteFailure = oktaMvcOptions.OnOktaException;
+                oidcOptions.Events.OnRemoteFailure = oktaMvcOptions.OnOktaApiFailure;
             }
 
             if (oktaMvcOptions.OnAuthenticationFailed != null)

--- a/docs/aspnet4x-mvc.md
+++ b/docs/aspnet4x-mvc.md
@@ -148,6 +148,7 @@ The `OktaMvcOptions` class configures the Okta middleware. You can see all the a
 | GetClaimsFromUserInfoEndpoint | No       | Whether to retrieve additional claims from the UserInfo endpoint after login. The default value is `true`. |
 | ClockSkew                 | No           | The clock skew allowed when validating tokens. The default value is 2 minutes. |
 | SecurityTokenValidated                 | No           | The event invoked after the security token has passed validation and a `ClaimsIdentity` has been generated. |
+| OnAuthenticationFailed    | No           | The event invoked if exceptions are thrown during request processing. |
 
 You can store these values (except the Token event) in the `Web.config`, but be careful when checking in the client secret to the source control.
 

--- a/docs/aspnet4x-mvc.md
+++ b/docs/aspnet4x-mvc.md
@@ -103,6 +103,33 @@ public ActionResult LoginWithIdp(string idp)
 
 The Okta.AspNet library will include your identity provider id in the authorize URL and the user will prompted with the identity provider login. For more information, check out our guides to [add an external identity provider](https://developer.okta.com/docs/guides/add-an-external-idp/).
 
+# Handling failures
+
+In the event a failure occurs, the Okta.AspNet library provides the `OnAuthenticationFailed` delegate defined on the `OktaMvcOptions` class. The following is an example of how to use `OnAuthenticationFailed` to handle authentication failures:
+
+```csharp
+public class Startup
+{
+    public void Configuration(IAppBuilder app)
+    {
+        app.UseOktaMvc(new OktaMvcOptions()
+        {
+            // ... other configuration options removed for brevity ...
+            AuthenticationFailed = OnAuthenticationFailed,
+        });
+    }
+
+    public async Task OnAuthenticationFailed(AuthenticationFailedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> notification)
+    {
+        await Task.Run(() =>
+        {
+            notification.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?message=" + notification.Exception.Message);
+            notification.HandleResponse();
+        });
+    }
+}
+```
+
 # Configuration Reference
 
 The `OktaMvcOptions` class configures the Okta middleware. You can see all the available options in the table below:

--- a/docs/aspnetcore-mvc.md
+++ b/docs/aspnetcore-mvc.md
@@ -129,7 +129,7 @@ public class Startup
 
     public async Task OnAuthenticationFailed(AuthenticationFailedContext context)
     {
-        await Task.Run(()=>
+        await Task.Run(() =>
         {
             context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?message=" + context.Exception.Message);
             context.HandleResponse();
@@ -158,5 +158,7 @@ The `OktaMvcOptions` class configures the Okta middleware. You can see all the a
 | ClockSkew                 | No           | The clock skew allowed when validating tokens. The default value is 2 minutes. |
 | OnTokenValidated                 | No           | The event invoked after the security token has passed validation and a ClaimsIdentity has been generated. |
 | OnUserInformationReceived                 | No           | The event invoked when user information is retrieved from the UserInfoEndpoint. The `GetClaimsFromUserInfoEndpoint` value must be `true` when using this event. |
+| OnOktaApiFailure          | No           | The event invoked when a failure occurs within the Okta API. |
+| OnAuthenticationFailed    | No           | The event invoked if exceptions are thrown during request processing. |
 
 You can store these values (except the events) in the `appsettings.json`, but be careful when checking in the client secret to the source control.

--- a/docs/aspnetcore-mvc.md
+++ b/docs/aspnetcore-mvc.md
@@ -122,7 +122,7 @@ public class Startup
     {
         await Task.Run(() =>
         {
-            context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?" + context.Failure.Message);
+            context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?message=" + context.Failure.Message);
             context.HandleResponse();
         });
     }
@@ -131,7 +131,7 @@ public class Startup
     {
         await Task.Run(()=>
         {
-            context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?" + context.Exception.Message);
+            context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?message=" + context.Exception.Message);
             context.HandleResponse();
         });
     }

--- a/docs/aspnetcore-mvc.md
+++ b/docs/aspnetcore-mvc.md
@@ -101,6 +101,44 @@ public IActionResult SignInWithIdp(string idp)
 }
 ```
 
+# Handling failures
+
+In the event a failure occurs, the Okta.AspNetCore library provides the `OnOktaApiFailure` and `OnAuthenticationFailed` delegates defined on the `OktaMvcOptions` class. The following is an example of how to use `OnOktaApiFailure` and `OnAuthenticationFailed` to handle failures:
+
+```csharp
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddOktaMvc(new OktaMvcOptions
+        {
+            // ... other configuration options removed for brevity ...
+            OnOktaApiFailure = OnOktaApiFailure,
+            OnAuthenticationFailed = OnAuthenticationFailed,
+        });
+    }
+
+    public async Task OnOktaApiFailure(RemoteFailureContext context)
+    {
+        await Task.Run(() =>
+        {
+            context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?" + context.Failure.Message);
+            context.HandleResponse();
+        });
+    }
+
+    public async Task OnAuthenticationFailed(AuthenticationFailedContext context)
+    {
+        await Task.Run(()=>
+        {
+            context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?" + context.Exception.Message);
+            context.HttpContext.Session.Set("OktaException", model.GetBytes());
+            context.HandleResponse();
+        });
+    }
+}
+```
+
 The Okta.AspNetCore library will include your identity provider id in the authorize URL and the user will prompted with the identity provider login. For more information, check out our guides to [add an external identity provider](https://developer.okta.com/docs/guides/add-an-external-idp/).
 
 # Configuration Reference 

--- a/docs/aspnetcore-mvc.md
+++ b/docs/aspnetcore-mvc.md
@@ -132,7 +132,6 @@ public class Startup
         await Task.Run(()=>
         {
             context.Response.Redirect("{YOUR-EXCEPTION-HANDLING-ENDPOINT}?" + context.Exception.Message);
-            context.HttpContext.Session.Set("OktaException", model.GetBytes());
             context.HandleResponse();
         });
     }


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
[OKTA-296007](https://oktainc.atlassian.net/browse/OKTA-296007)


## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Unit test(s)
- [x] Implementation


## Current behavior
Unhandled exceptions occur if authentication failures occur in Okta api.


## Desired behavior
Provide a way for developers to handle authentication failures


## Additional Context
https://github.com/okta/okta-aspnet/issues/120

