### PR TITLE
OKTA-276823 ASP.NET > Add .NET runtime in the user agent report

### DIFF
--- a/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
+++ b/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="OktaWebOptionsValidatorShould.cs" company="Okta, Inc">
+// Copyright (c) 2018-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using FluentAssertions;
+using Xunit;
+
+namespace Okta.AspNet.Abstractions.Test
+{
+    public class UserAgentHelperShould
+    {
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("foo .NET")]
+        [InlineData(".NET")]
+        [InlineData(".NET foo")]
+        [InlineData(".NET Framework 4.8")]
+        public void ReturnPassedFrameworkDescriptionIfItDoesNotStartWithKeyword(string runtimeDescription)
+        {
+            // Keyword for runtimeDescription = ".NET Core"
+            var frameworkInfo = UserAgentHelper.GetFrameworkDescription(runtimeDescription);
+
+            frameworkInfo.Should().Be(runtimeDescription);
+        }
+
+        [Theory]
+        [InlineData("file:///C:/Program Files/dotnet/shared/Microsoft.NETCore.App/2.0.9/System.Private.CoreLib.dll", "2.0.9")]
+        [InlineData("Microsoft.NETCore.App/2.0.9/System.Private.CoreLib.dll", "2.0.9")]
+        [InlineData("foo/Microsoft.NETCore.App/2.0.9/System.Private.CoreLib.dll", "2.0.9")]
+        [InlineData("foo/Microsoft.NETCore.App/3.1.1/System.Private.CoreLib.dll", "3.1.1")]
+        public void ReturnNormalizedFrameworkDescriptionWhenItStartsWithKeywordAndCodeBaseHasKeyword(string runtimeAssemblyCodeBase, string expectedVersion)
+        {
+            // Keyword for runtimeDescription = ".NET Core"
+            // Keyword for codeBase = "Microsoft.NETCore.App"
+            var frameworkInfo = UserAgentHelper.GetFrameworkDescription(".NET Core", runtimeAssemblyCodeBase);
+
+            frameworkInfo.Should().Be($".NET Core {expectedVersion}");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.App/2.0.9/System.Private.CoreLib.dll")]
+        [InlineData("foo/Microsoft.NETCore.foo/2.0.9/System.Private.CoreLib.dll")]
+        [InlineData("foo/Microsoft.NETCore.Apps/3.1.1/System.Private.CoreLib.dll")]
+        public void ReturnPassedFrameworkDescriptionWhenAssemblyCodeBaseDoesNotContainKeyword(string runtimeAssemblyCodeBase)
+        {
+            // Keyword for runtimeDescription = ".NET Core"
+            // Keyword for codeBase = "Microsoft.NETCore.App"
+            var frameworkInfo = UserAgentHelper.GetFrameworkDescription(".NET Core foo", runtimeAssemblyCodeBase);
+
+            frameworkInfo.Should().Be(".NET Core foo");
+        }
+
+        [Fact]
+        public void ReturnPassedFrameworkDescriptionWhenAssemblyCodeBaseContainsKeywordButNotVersion()
+        {
+            // Keyword for runtimeDescription = ".NET Core"
+            // Keyword for codeBase = "Microsoft.NETCore.App"
+            var frameworkInfo = UserAgentHelper.GetFrameworkDescription(".NET Core foo", "foo/Microsoft.NETCore.App");
+
+            frameworkInfo.Should().Be(".NET Core foo");
+        }
+    }
+}

--- a/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
+++ b/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OktaWebOptionsValidatorShould.cs" company="Okta, Inc">
+﻿// <copyright file="UserAgentHelperShould.cs" company="Okta, Inc">
 // Copyright (c) 2018-present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>

--- a/Okta.AspNet.Abstractions/UserAgentBuilder.cs
+++ b/Okta.AspNet.Abstractions/UserAgentBuilder.cs
@@ -4,7 +4,7 @@
 // </copyright>
 
 using System;
-using System.Runtime.InteropServices;
+using System.Linq;
 
 namespace Okta.AspNet.Abstractions
 {
@@ -21,18 +21,18 @@ namespace Okta.AspNet.Abstractions
         }
 
         public string GetUserAgent()
-        {
-            return string.Join(" ", GetOSVersion(), GetFrameworkVersion());
-        }
+            => $"{GetFrameworkVersion()} {GetRuntimeVersion()} {GetOSVersion()}";
 
         private string GetFrameworkVersion()
-        {
-            return $"{_frameworkName}{VersionSeparator}{_frameworkVersion.Major}.{_frameworkVersion.Minor}.{_frameworkVersion.Build}";
-        }
+            => $"{_frameworkName}{VersionSeparator}{_frameworkVersion.Major}.{_frameworkVersion.Minor}.{_frameworkVersion.Build}";
+
+        private object GetRuntimeVersion()
+            => $"runtime{VersionSeparator}{Sanitize(UserAgentHelper.GetFrameworkDescription())}";
 
         private string GetOSVersion()
-        {
-            return $"os-version{VersionSeparator}{Environment.OSVersion.VersionString}{VersionSeparator}{Environment.OSVersion.Platform}";
-        }
+            => $"os-version{VersionSeparator}{Environment.OSVersion.VersionString}{VersionSeparator}{Environment.OSVersion.Platform}";
+
+        private string Sanitize(string input)
+            => new[] { '/', ':', ';' }.Aggregate(input, (current, bad) => current.Replace(bad, '-'));
     }
 }

--- a/Okta.AspNet.Abstractions/UserAgentHelper.cs
+++ b/Okta.AspNet.Abstractions/UserAgentHelper.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="UserAgentHelper.cs" company="Okta, Inc">
+// Copyright (c) 2018-present Okta, Inc. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Okta.AspNet.Abstractions
+{
+    /// <summary>
+    /// User-agent helper.
+    /// </summary>
+    public class UserAgentHelper
+    {
+        /// <summary>
+        /// Returns a normalized framework version description.
+        /// </summary>
+        /// <param name="runtimeFrameworkDescription">The runtime description.</param>
+        /// <param name="runtimeAssemblyCodeBase">The runtime code base.</param>
+        /// <returns>The normalized framework desctiption.</returns>
+        public static string GetFrameworkDescription(string runtimeFrameworkDescription = "", string runtimeAssemblyCodeBase = "")
+        {
+            var frameworkDescription = string.IsNullOrEmpty(runtimeFrameworkDescription) ? RuntimeInformation.FrameworkDescription : runtimeFrameworkDescription;
+            var assemblyCodeBase = runtimeAssemblyCodeBase;
+
+            // RuntimeInformation.FrameworkDescription only returns the CLI version for .NET Core.
+            // We need this workaround to get the product version and have a useful report.
+            if (frameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrEmpty(assemblyCodeBase))
+                {
+                    assemblyCodeBase = typeof(System.Runtime.GCSettings).GetTypeInfo().Assembly?.CodeBase;
+                }
+
+                if (assemblyCodeBase != null)
+                {
+                    var runtimeAssemblyLocation = assemblyCodeBase.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+                    int dotnetCoreAppIndex = Array.IndexOf(runtimeAssemblyLocation, "Microsoft.NETCore.App");
+
+                    if (dotnetCoreAppIndex >= 0 && dotnetCoreAppIndex < runtimeAssemblyLocation.Length - 2)
+                    {
+                        frameworkDescription = $".NET Core {runtimeAssemblyLocation[dotnetCoreAppIndex + 1]}";
+                    }
+                }
+            }
+
+            return frameworkDescription;
+        }
+    }
+}


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->
https://oktainc.atlassian.net/browse/OKTA-276823

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Unit test(s)
- [x] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->
Example of current UserAgent string `os-version/Microsoft Windows NT 10.0.17763.0/Win32NT okta-aspnetcore/3.3.0
`
## Desired behavior
<!-- Describe what the desired behavior is. -->
Changed to look like this: `okta-aspnetcore/3.3.0 runtime/.NET Core 3.1.8 os-version/Microsoft Windows NT 10.0.17763.0/Win32NT`
* Added code for detecting runtime version and UTs for it. Everything is taken from Okta.Sdk with little changes.
* Order of the tokens in UserAgent string was changed to match the one from Okta.Sdk. (`operatingSystem, sdk` ==> `sdk,  runtime, operatingSystem`)

## Additional Context
<!-- Describe the motivation or the concrete use case. -->

