### PR TITLE
#191 Add support for configuring auth schemes

### DIFF
--- a/Okta.AspNetCore.Mvc.IntegrationTest/Controllers/AccountWithSchemeController.cs
+++ b/Okta.AspNetCore.Mvc.IntegrationTest/Controllers/AccountWithSchemeController.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Okta.AspNet.Abstractions;
+
+namespace Okta.AspNetCore.Mvc.IntegrationTest.Controllers
+{
+    public class AccountWithSchemeController : Controller
+    {
+        public IActionResult Login()
+        {
+            if (!HttpContext.User.Identity.IsAuthenticated)
+            {
+                return Challenge("CustomScheme");
+            }
+
+            return RedirectToAction("Index", "Home");
+        }
+
+        public IActionResult LoginWithIdp()
+        {
+            if (!HttpContext.User.Identity.IsAuthenticated)
+            {
+                var properties = new AuthenticationProperties();
+                properties.Items.Add("idp", "foo");
+                properties.RedirectUri = "/Home/";
+
+                return Challenge(properties, "CustomScheme");
+            }
+
+            return RedirectToAction("Index", "Home");
+        }
+
+        public IActionResult LoginWithLoginHint()
+        {
+            if (!HttpContext.User.Identity.IsAuthenticated)
+            {
+                var properties = new AuthenticationProperties();
+                properties.Items.Add(OktaParams.LoginHint, "foo");
+                properties.RedirectUri = "/Home/";
+
+                return Challenge(properties, "CustomScheme");
+            }
+
+            return RedirectToAction("Index", "Home");
+        }
+
+        [HttpPost]
+        public IActionResult Logout()
+        {
+            return new SignOutResult(new[] { "CustomScheme", CookieAuthenticationDefaults.AuthenticationScheme });
+        }
+
+        [Authorize]
+        [HttpGet]
+        public IActionResult Claims()
+        {
+            return View(HttpContext.User.Claims);
+        }
+    }
+}

--- a/Okta.AspNetCore.Mvc.IntegrationTest/OktaMiddlewareShouldWithCustomSchemeShould.cs
+++ b/Okta.AspNetCore.Mvc.IntegrationTest/OktaMiddlewareShouldWithCustomSchemeShould.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Okta.AspNetCore.Mvc.IntegrationTest
+{
+    public class OktaMiddlewareShouldWithCustomSchemeShould : IDisposable
+    {
+        private readonly TestServer _server;
+
+        private string BaseUrl { get; set; }
+
+        private string ProtectedEndpoint { get; set; }
+
+        public IConfiguration Configuration { get; set; }
+
+        public OktaMiddlewareShouldWithCustomSchemeShould()
+        {
+            Configuration = TestConfiguration.GetConfiguration();
+            BaseUrl = "http://localhost:57451";
+            ProtectedEndpoint = string.Format("{0}/AccountWithScheme/Claims", BaseUrl);
+            _server = new TestServer(new WebHostBuilder()
+            .UseStartup<StartupUsingCustomScheme>()
+            .UseConfiguration(Configuration))
+            {
+                BaseAddress = new Uri(BaseUrl),
+            };
+        }
+
+        [Fact]
+        public async Task RedirectWhenAccessToProtectedRouteWithoutSignedInAsync()
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, ProtectedEndpoint);
+            using (var client = _server.CreateClient())
+            {
+                var response = await client.GetAsync(ProtectedEndpoint);
+                Assert.True(response.StatusCode == System.Net.HttpStatusCode.Found);
+                Assert.StartsWith(Configuration["Okta:OktaDomain"], response.Headers.Location.AbsoluteUri);
+            }
+        }
+
+        [Fact]
+        public async Task IncludeIdpInAuthorizeUrlAsync()
+        {
+            var loginWithIdpEndpoint = string.Format("{0}/AccountWithScheme/LoginWithIdp", BaseUrl);
+            using (var client = _server.CreateClient())
+            {
+                var response = await client.GetAsync(loginWithIdpEndpoint);
+                Assert.True(response.StatusCode == System.Net.HttpStatusCode.Found);
+                Assert.Contains("idp=foo", response.Headers.Location.AbsoluteUri);
+            }
+        }
+
+        [Fact]
+        public async Task IncludeLoginHintInAuthorizeUrlAsync()
+        {
+            var loginWithLoginHintEndpoint = string.Format("{0}/AccountWithScheme/LoginWithLoginHint", BaseUrl);
+            using (var client = _server.CreateClient())
+            {
+                var response = await client.GetAsync(loginWithLoginHintEndpoint);
+                Assert.True(response.StatusCode == System.Net.HttpStatusCode.Found);
+                Assert.Contains("login_hint=foo", response.Headers.Location.AbsoluteUri);
+            }
+        }
+
+        [Fact]
+        public async Task CallCustomRedirectEventAfterInternalEventAsync()
+        {
+            var loginWithIdpEndpoint = string.Format("{0}/AccountWithScheme/LoginWithIdp", BaseUrl);
+            using (var client = _server.CreateClient())
+            {
+                var response = await client.GetAsync(loginWithIdpEndpoint);
+                Assert.True(response.StatusCode == System.Net.HttpStatusCode.Found);
+                Assert.Contains("idp=foo", response.Headers.Location.AbsoluteUri);
+                Assert.Contains("myCustomParamKey=myCustomParamValue", response.Headers.Location.AbsoluteUri);
+            }
+        }
+
+        public void Dispose()
+        {
+            _server.Dispose();
+        }
+    }
+}

--- a/Okta.AspNetCore.Mvc.IntegrationTest/StartupUsingCustomScheme.cs
+++ b/Okta.AspNetCore.Mvc.IntegrationTest/StartupUsingCustomScheme.cs
@@ -10,9 +10,11 @@ using Microsoft.Extensions.Hosting;
 
 namespace Okta.AspNetCore.Mvc.IntegrationTest
 {
-    public class Startup
+    public class StartupUsingCustomScheme
     {
-        public Startup()
+        private const string CustomScheme = "CustomScheme";
+
+        public StartupUsingCustomScheme()
         {
             var builder = new ConfigurationBuilder();
             builder
@@ -41,11 +43,11 @@ namespace Okta.AspNetCore.Mvc.IntegrationTest
             services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = CustomScheme;
                 options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
             })
             .AddCookie()
-            .AddOktaMvc(new OktaMvcOptions()
+            .AddOktaMvc(CustomScheme, new OktaMvcOptions()
             {
                 ClientId = Configuration["Okta:ClientId"],
                 ClientSecret = Configuration["Okta:ClientSecret"],

--- a/Okta.AspNetCore.Mvc.IntegrationTest/TestConfiguration.cs
+++ b/Okta.AspNetCore.Mvc.IntegrationTest/TestConfiguration.cs
@@ -15,8 +15,9 @@ namespace Okta.AspNetCore.Mvc.IntegrationTest
             if (_configuration == null)
             {
                 _configuration = new ConfigurationBuilder()
-                .AddEnvironmentVariables()
-                .Build();
+                    .AddJsonFile("appsettings.json")
+                    .AddEnvironmentVariables()
+                    .Build();
             }
 
             return _configuration;

--- a/Okta.AspNetCore.Mvc.IntegrationTest/appsettings.json
+++ b/Okta.AspNetCore.Mvc.IntegrationTest/appsettings.json
@@ -1,9 +1,14 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "Okta": {
+        "OktaDomain": "",
+        "ClientId": "",
+        "ClientSecret": ""
     }
-  }
 }

--- a/Okta.AspNetCore.WebApi.IntegrationTest/OktaMiddlewareWithCustomSchemeShould.cs
+++ b/Okta.AspNetCore.WebApi.IntegrationTest/OktaMiddlewareWithCustomSchemeShould.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Okta.AspNetCore.WebApi.IntegrationTest
+{
+    public class OktaMiddlewareWithCustomSchemeShould : IDisposable
+    {
+        private readonly TestServer _server;
+
+        private string BaseUrl { get; set; }
+
+        private string ProtectedEndpoint { get; set; }
+
+        public IConfiguration Configuration { get; set; }
+
+        public OktaMiddlewareWithCustomSchemeShould()
+        {
+            Configuration = TestConfiguration.GetConfiguration();
+            BaseUrl = "http://localhost:58533";
+            ProtectedEndpoint = $"{BaseUrl}/api/messages";
+            _server = new TestServer(new WebHostBuilder()
+            .UseStartup<StartupUsingCustomScheme>()
+            .UseConfiguration(Configuration))
+            {
+                BaseAddress = new Uri(BaseUrl),
+            };
+        }
+
+        [Fact]
+        public async Task Returns401WhenAccessToProtectedRouteWithoutTokenAsync()
+        {
+            using (var client = new HttpClient(_server.CreateHandler()))
+            {
+                var response = await client.GetAsync(ProtectedEndpoint);
+                Assert.True(response.StatusCode == System.Net.HttpStatusCode.Unauthorized);
+            }
+        }
+
+        [Fact]
+        public async Task Returns401WhenAccessToProtectedRouteWithInvalidTokenAsync()
+        {
+            var accessToken = "thisIsAnInvalidToken";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, ProtectedEndpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            using (var client = new HttpClient(_server.CreateHandler()))
+            {
+                var response = await client.SendAsync(request);
+                Assert.True(response.StatusCode == System.Net.HttpStatusCode.Unauthorized);
+            }
+        }
+
+        [Fact]
+        public async Task InvokeCustomEventsAsync()
+        {
+            var accessToken = "thisIsAnInvalidToken";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, ProtectedEndpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            using (var client = new HttpClient(_server.CreateHandler()))
+            {
+                var response = await client.SendAsync(request);
+                Assert.True(response.Headers.Contains("myCustomHeader"));
+            }
+        }
+
+        public void Dispose()
+        {
+            _server.Dispose();
+        }
+    }
+}

--- a/Okta.AspNetCore.WebApi.IntegrationTest/Startup.cs
+++ b/Okta.AspNetCore.WebApi.IntegrationTest/Startup.cs
@@ -15,7 +15,9 @@ namespace Okta.AspNetCore.WebApi.IntegrationTest
         public Startup()
         {
             var builder = new ConfigurationBuilder();
-            builder.AddEnvironmentVariables();
+            builder
+                .AddJsonFile("appsettings.json")
+                .AddEnvironmentVariables();
             Configuration = builder.Build();
         }
 

--- a/Okta.AspNetCore.WebApi.IntegrationTest/TestConfiguration.cs
+++ b/Okta.AspNetCore.WebApi.IntegrationTest/TestConfiguration.cs
@@ -11,6 +11,7 @@ namespace Okta.AspNetCore.WebApi.IntegrationTest
             if (_configuration == null)
             {
                 _configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
                 .AddEnvironmentVariables()
                 .Build();
             }

--- a/Okta.AspNetCore.WebApi.IntegrationTest/appsettings.json
+++ b/Okta.AspNetCore.WebApi.IntegrationTest/appsettings.json
@@ -1,9 +1,12 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "Okta": {
+        "OktaDomain": ""
     }
-  }
 }


### PR DESCRIPTION
## Summary
<!-- Be concise with your summary, but explain what changed -->
Adds additional overloads for OktaAuthenticationOptionsExtensions to specify an authentication scheme.

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes #191 

## Type of PR
<!-- Multiple selections are ok -->
- [ ] Bug Fix (non-breaking fixes to existing functionality)
- [x] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [x] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

.NET Version:
Os Version:

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I checked StyleCop warnings on my code

