### PR TITLE
Update authorize request's params accordingly when prompt=enroll_authenticator

### DIFF
--- a/Okta.AspNet.Abstractions/OktaParams.cs
+++ b/Okta.AspNet.Abstractions/OktaParams.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 
 namespace Okta.AspNet.Abstractions
@@ -44,9 +45,20 @@ namespace Okta.AspNet.Abstractions
         /// </summary>
         public const string EnrollAmrValues = "enroll_amr_values";
 
+        private const string EnrollAuthenticator = "enroll_authenticator";
+
         /// <summary>
         /// A list with all Okta well-known params.
         /// </summary>
         public static readonly IList<string> AllParams = new List<string>() { SessionToken, Idp, LoginHint, AcrValues, Prompt, EnrollAmrValues };
+
+        /// <summary>
+        /// Returns true if the request includes prompt=enroll_authenticator, false otherwise.
+        /// </summary>
+        /// <param name="parameters">The request parameters</param>
+        public static bool IsPromptEnrollAuthenticator(IDictionary<string, string> parameters) =>
+            parameters != null &&
+            parameters.ContainsKey(Prompt) &&
+            parameters[Prompt].Equals(EnrollAuthenticator, StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/Okta.AspNet/CHANGELOG.md
+++ b/Okta.AspNet/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `1.6.0`
 
+## 3.2.1
+
+### Features
+
+- Update authorization request's params accordingly when `prompt=enroll_authenticator`
+
 ## v3.2.0
 
 ### Features

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Official Okta middleware for ASP.NET 4.6.2+. Easily add authentication and authorization to ASP.NET applications.</Description>
     <Copyright>(c) 2019 Okta, Inc.</Copyright>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
     <Authors>Okta, Inc.</Authors>
     <TargetFramework>net462</TargetFramework>
     <AssemblyName>Okta.AspNet</AssemblyName>
@@ -30,8 +30,8 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>3.0.2.0</AssemblyVersion>
-    <FileVersion>3.0.2.0</FileVersion>
+    <AssemblyVersion>3.0.2.1</AssemblyVersion>
+    <FileVersion>3.0.2.1</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
+++ b/Okta.AspNet/OpenIdConnectAuthenticationOptionsBuilder.cs
@@ -124,6 +124,23 @@ namespace Okta.AspNet
                         redirectToIdentityProviderNotification.ProtocolMessage.SetParameter(oktaParamKey, oktaRequestParamValue);
                     }
                 }
+
+                if (OktaParams.IsPromptEnrollAuthenticator(redirectToIdentityProviderNotification.ProtocolMessage.Parameters))
+                {
+                    var redirectUri =
+                        redirectToIdentityProviderNotification.OwinContext.Authentication
+                            .AuthenticationResponseChallenge?.Properties?.RedirectUri ??
+                        redirectToIdentityProviderNotification.ProtocolMessage.RedirectUri;
+
+                    // ACR values should be provided by the user.
+                    // scope, nonce, and resource must be omitted.
+                    redirectToIdentityProviderNotification.ProtocolMessage.ResponseType = "none";
+                    redirectToIdentityProviderNotification.ProtocolMessage.MaxAge = "0";
+                    redirectToIdentityProviderNotification.ProtocolMessage.Nonce = null;
+                    redirectToIdentityProviderNotification.ProtocolMessage.Scope = null;
+                    redirectToIdentityProviderNotification.ProtocolMessage.Resource = null;
+                    redirectToIdentityProviderNotification.ProtocolMessage.RedirectUri = redirectUri;
+                }
             }
 
             if (redirectEvent != null)

--- a/Okta.AspNetCore/CHANGELOG.md
+++ b/Okta.AspNetCore/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `3.2.0`
 
+## v4.4.1
+
+### Features
+
+- Update authorization request's params accordingly when `prompt=enroll_authenticator`
+
 ## v4.4.0
 
 ### Features

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -7,8 +7,8 @@
 	<PropertyGroup>
 		<Description>Official Okta middleware for ASP.NET Core 3.1+. Easily add authentication and authorization to ASP.NET Core applications.</Description>
 		<Copyright>(c) 2020 - present Okta, Inc. All rights reserved.</Copyright>
-		<Version>4.4.0</Version>
-		<VersionPrefix>4.4.0</VersionPrefix>
+		<Version>4.4.1</Version>
+		<VersionPrefix>4.4.1</VersionPrefix>
 		<Authors>Okta, Inc.</Authors>
 		<AssemblyName>Okta.AspNetCore</AssemblyName>
 		<PackageId>Okta.AspNetCore</PackageId>

--- a/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
+++ b/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
@@ -132,6 +132,19 @@ namespace Okta.AspNetCore
                 }
             }
 
+            if (OktaParams.IsPromptEnrollAuthenticator(context.ProtocolMessage.Parameters))
+            {
+                // ACR values should be provided by the user.
+                // scope, nonce, and resource must be omitted by the server.
+                context.ProtocolMessage.ResponseType = "none";
+                context.ProtocolMessage.MaxAge = "0";
+                context.ProtocolMessage.Nonce = null;
+                context.ProtocolMessage.Scope = null;
+                context.ProtocolMessage.Resource = null;
+                context.ProtocolMessage.RedirectUri = context.Properties.RedirectUri;
+
+            }
+
             if (redirectEvent != null)
             {
                 return redirectEvent(context);

--- a/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
+++ b/Okta.AspNetCore/OktaAuthenticationOptionsExtensions.cs
@@ -141,7 +141,7 @@ namespace Okta.AspNetCore
                 context.ProtocolMessage.Nonce = null;
                 context.ProtocolMessage.Scope = null;
                 context.ProtocolMessage.Resource = null;
-                context.ProtocolMessage.RedirectUri = context.Properties.RedirectUri;
+                context.ProtocolMessage.RedirectUri = context?.Properties?.RedirectUri ?? context.ProtocolMessage.RedirectUri;
 
             }
 

--- a/docs/aspnet4x-mvc.md
+++ b/docs/aspnet4x-mvc.md
@@ -189,7 +189,7 @@ public ActionResult Login()
 |`prompt` | Indicate the pipeline the intent of the request, such as, support enrollment of a new factor. | No |
 |`enroll_amr_values` |  A space-delimited, case-sensitive string that represents a list of authenticator method references. | No |
 
-> Note: When `prompt` is equals to `enroll_authenticator` you have to also indicate the `redirect_uri`. The `redirect_uri` cannot be the same as the normal OIDC flow `/authorization_code/callback` since there's no code involved in this flow. Instead, you have to specify a callback URI (which has to be added to your application's allowed URLs in your Okta dashboard) in your application where, for example, you can process the response and redirect accordingly. Also, it's expected you to already have a session before triggering the authenticator enrollment flow.
+> Note: When `prompt` is equals to `enroll_authenticator` you have to indicate the URL that Okta should send callback to after the user app sends the enrollment request. The `redirect_uri` cannot be the same as the normal OIDC flow `/authorization_code/callback` since there's no code involved in this flow. Instead, you have to specify a callback URI (which has to be added to your application's allowed URLs in your Okta dashboard) in your application where, for example, you can process the response and redirect accordingly. Also, it's expected you already have a session before triggering the authenticator enrollment flow.
 
 
 For more details see the [Okta documentation](https://developer.okta.com/docs/reference/api/oidc/#request-parameters).

--- a/docs/aspnetcore-mvc.md
+++ b/docs/aspnetcore-mvc.md
@@ -276,7 +276,7 @@ public IActionResult SignIn()
 |`enroll_amr_values` |  A space-delimited, case-sensitive string that represents a list of authenticator method references. | No |
 
 
-> Note: When `prompt` is equals to `enroll_authenticator` you have to also indicate the `redirect_uri`. The `redirect_uri` cannot be the same as the normal OIDC flow `/authorization_code/callback` since there's no code involved in this flow. Instead, you have to specify a callback URI (which has to be added to your application's allowed URLs in your Okta dashboard) in your application where, for example, you can process the response and redirect accordingly. Also, it's expected you to already have a session before triggering the authenticator enrollment flow.
+> Note: When `prompt` is equals to `enroll_authenticator` you have to indicate the URL that Okta should send callback to after the user app sends the enrollment request. The `redirect_uri` cannot be the same as the normal OIDC flow `/authorization_code/callback` since there's no code involved in this flow. Instead, you have to specify a callback URI (which has to be added to your application's allowed URLs in your Okta dashboard) in your application where, for example, you can process the response and redirect accordingly. Also, it's expected you already have a session before triggering the authenticator enrollment flow.
 
 For more details see the [Okta documentation](https://developer.okta.com/docs/reference/api/oidc/#request-parameters).
 


### PR DESCRIPTION
- Update OIDC logic to send `responseType=none`, `max_age=0` and omit `scope`, `resource` and `none` when `prompt=enroll_authenticator`
- Update docs indicating prerequisites to use this feature
- Update changelog
- Update projects' version