### PR TITLE
Fix "Method not found:Boolean Okta.AspNet.Abstractions.OktaParams.IsromptEnrollAuthenticator" issue

### DIFF
--- a/Okta.AspNet.Abstractions/CHANGELOG.md
+++ b/Okta.AspNet.Abstractions/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `3.0.5`
 
+## v4.2.1
+
+### Bug Fixes
+
+- Fix "Method not found:Boolean Okta.AspNet.Abstractions.OktaParams.IsPromptEnrollAuthenticator" issue (#228)
+
 ## v4.2.0
 
 ### Features

--- a/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
+++ b/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
@@ -36,8 +36,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
-    <AssemblyVersion>3.2.2.0</AssemblyVersion>
-    <FileVersion>3.2.2.0</FileVersion>
+    <AssemblyVersion>4.2.1.0</AssemblyVersion>
+    <FileVersion>4.2.1.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
+++ b/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <Version>4.2.0</Version>
+    <Version>4.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Okta.AspNet/CHANGELOG.md
+++ b/Okta.AspNet/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `1.6.0`
 
+## 3.2.2
+
+### Bug Fixes
+
+- Fix "Method not found:Boolean Okta.AspNet.Abstractions.OktaParams.IsPromptEnrollAuthenticator" issue (#228)
+
 ## 3.2.1
 
 ### Features

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -30,8 +30,8 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>3.0.2.1</AssemblyVersion>
-    <FileVersion>3.0.2.1</FileVersion>
+    <AssemblyVersion>3.0.2.2</AssemblyVersion>
+    <FileVersion>3.0.2.2</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Official Okta middleware for ASP.NET 4.6.2+. Easily add authentication and authorization to ASP.NET applications.</Description>
     <Copyright>(c) 2019 Okta, Inc.</Copyright>
-    <Version>3.2.1</Version>
+    <Version>3.2.2</Version>
     <Authors>Okta, Inc.</Authors>
     <TargetFramework>net462</TargetFramework>
     <AssemblyName>Okta.AspNet</AssemblyName>

--- a/Okta.AspNetCore/CHANGELOG.md
+++ b/Okta.AspNetCore/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 Running changelog of releases since `3.2.0`
 
+## v4.4.2
+
+### Bug Fixes
+
+- Fix "Method not found:Boolean Okta.AspNet.Abstractions.OktaParams.IsPromptEnrollAuthenticator" issue (#228)
+
 ## v4.4.1
 
 ### Features

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -7,8 +7,8 @@
 	<PropertyGroup>
 		<Description>Official Okta middleware for ASP.NET Core 3.1+. Easily add authentication and authorization to ASP.NET Core applications.</Description>
 		<Copyright>(c) 2020 - present Okta, Inc. All rights reserved.</Copyright>
-		<Version>4.4.1</Version>
-		<VersionPrefix>4.4.1</VersionPrefix>
+		<Version>4.4.2</Version>
+		<VersionPrefix>4.4.2</VersionPrefix>
 		<Authors>Okta, Inc.</Authors>
 		<AssemblyName>Okta.AspNetCore</AssemblyName>
 		<PackageId>Okta.AspNetCore</PackageId>

--- a/docs/aspnet4x-mvc.md
+++ b/docs/aspnet4x-mvc.md
@@ -267,13 +267,41 @@ public class HomeController : Controller
 
 This example assumes you have a view called `Claim` whose model is of type `System.Security.Claims.Claim`. The claim types for OIDC tokens are `id_token` and `access_token` as well as `refresh_token` if available.
 
-## Handling failures
+## Hooking into OIDC events
 
-This library exposes [OpenIdConnectEvents](https://docs.microsoft.com/en-us/previous-versions/aspnet/mt180963(v=vs.113)) so you can hook into specific events during the authentication process. For more information see [`AuthenticationFailed`](https://docs.microsoft.com/en-us/previous-versions/aspnet/mt180967(v=vs.113)).
+This library exposes [OpenIdConnectEvents](https://docs.microsoft.com/en-us/previous-versions/aspnet/mt180963(v=vs.113)) so you can hook into specific events during the authentication process.
 
+### Adding custom claims  
+
+The following is an example of how to use events to add custom claims to the token:
+
+```csharp
+public class Startup
+{
+    public void Configuration(IAppBuilder app)
+    {
+        app.UseOktaMvc(new OktaMvcOptions()
+        {
+            // ... other configuration options removed for brevity ...
+             OpenIdConnectEvents = new OpenIdConnectAuthenticationNotifications
+                {
+                    SecurityTokenValidated = (notification) =>
+                    {
+                        notification.AuthenticationTicket.Identity.AddClaim(new Claim("CodeCustomClaimKey", "CodeCustomClaimValue"));
+
+                        return Task.CompletedTask;
+                    }
+                },
+        });
+    }
+}
+```
+
+> Note: For more information see [`SecurityTokenValidated`](https://learn.microsoft.com/en-us/previous-versions/aspnet/mt180993(v=vs.113))
+
+### Handling failures
 
  The following is an example of how to use events to handle failures:
-
 
 ```csharp
 public class Startup
@@ -300,6 +328,7 @@ public class Startup
     }
 }
 ```
+> Note: For more information see [`AuthenticationFailed`](https://docs.microsoft.com/en-us/previous-versions/aspnet/mt180967(v=vs.113))
 
 # Configuration Reference
 

--- a/docs/aspnetcore-mvc.md
+++ b/docs/aspnetcore-mvc.md
@@ -357,10 +357,39 @@ public class HomeController : Controller
 
 This example assumes you have a view called `OIDCToken` whose model is of type `TokenModel`. The OIDC tokens are `id_token` and `access_token` as well as `refresh_token` if available.
 
-## Handling failures
+## Hooking into OIDC events
 
-In the event a failure occurs, the Okta.AspNetCore library exposes [OpenIdConnectEvents](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.openidconnect.openidconnectevents.onauthenticationfailed) so you can hook into specific events during the authentication process. For more information See [`OnAuthenticationFailed`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.openidconnect.openidconnectevents.onauthenticationfailed) or [`OnRemoteFailure`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationevents.onremotefailure).
+In the event a failure occurs, the Okta.AspNetCore library exposes [OpenIdConnectEvents](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.openidconnect.openidconnectevents.onauthenticationfailed) so you can hook into specific events during the authentication process.
 
+### Customizing claims
+
+ The following is an example of how to use events to add custom claims to the token:
+
+```csharp
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddOktaMvc(new OktaMvcOptions
+        {
+            // ... other configuration options removed for brevity ...
+            OpenIdConnectEvents = new OpenIdConnectEvents
+                                {
+                                    OnTokenValidated = context =>
+                                    {
+                                        ClaimsIdentity claimsIdentity = context.Principal.Identity as ClaimsIdentity;
+                                        claimsIdentity.AddClaim(new Claim("MyCustomClaimKey", "MyCustomClaimValue"));
+
+                                        return Task.CompletedTask;
+                                    }
+                                },
+        });
+    }
+```
+
+> Note: For more information See [`OnTokenValidated`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.openidconnect.openidconnectevents.ontokenvalidated).
+
+### Handling failures
 
  The following is an example of how to use events to handle failures:
 
@@ -399,6 +428,9 @@ public class Startup
     }
 }
 ```
+
+> Note:  For more information See [`OnAuthenticationFailed`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.openidconnect.openidconnectevents.onauthenticationfailed) or [`OnRemoteFailure`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationevents.onremotefailure).
+
 # Configuration Reference 
 
 The `OktaMvcOptions` class configures the Okta middleware. You can see all the available options in the table below:


### PR DESCRIPTION
In the previous release, we should also have released Okta.Abstractions.AspNet. In this PR, I make sure we update all the Okta.AspNet* packages and rerelease them.

Fixes #228 