### PR TITLE
OKTA-576349: update target framework for windows projects to v4.8.1

### DIFF
--- a/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
+++ b/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <Version>4.2.1</Version>
+    <TargetFrameworks>net481;netstandard2.0</TargetFrameworks>
+    <Version>4.2.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -36,8 +36,9 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
-    <AssemblyVersion>4.2.1.0</AssemblyVersion>
-    <FileVersion>4.2.1.0</FileVersion>
+    <AssemblyVersion>4.2.2.0</AssemblyVersion>
+    <FileVersion>4.2.2.0</FileVersion>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Okta.AspNet.Test/Okta.AspNet.Test.csproj
+++ b/Okta.AspNet.Test/Okta.AspNet.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Okta.AspNet.WebApi.IntegrationTest/Okta.AspNet.WebApi.IntegrationTest.csproj
+++ b/Okta.AspNet.WebApi.IntegrationTest/Okta.AspNet.WebApi.IntegrationTest.csproj
@@ -16,7 +16,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Okta.AspNet.WebApi.IntegrationTest</RootNamespace>
     <AssemblyName>Okta.AspNet.WebApi.IntegrationTest</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <Use64BitIISExpress />
     <IISExpressSSLPort>44314</IISExpressSSLPort>
@@ -72,6 +72,7 @@
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
     </Reference>
@@ -98,8 +99,6 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Http, Version=5.2.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.8\lib\net45\System.Web.Http.dll</HintPath>
@@ -110,13 +109,13 @@
     <Reference Include="System.Web.Http.WebHost, Version=5.2.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.8\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/Okta.AspNet.WebApi.IntegrationTest/Properties/Settings.Designer.cs
+++ b/Okta.AspNet.WebApi.IntegrationTest/Properties/Settings.Designer.cs
@@ -8,11 +8,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Okta.AspNet.Test.WebApi.Properties {
+namespace Okta.AspNet.WebApi.IntegrationTest.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Okta.AspNet.WebApi.IntegrationTest/Web.config
+++ b/Okta.AspNet.WebApi.IntegrationTest/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=301879
@@ -6,9 +6,9 @@
 <configuration>
   <appSettings>
     <!-- 1. Replace these values with your Okta configuration -->
-    <add key="okta:OktaDomain" value="https://{YourOktaDomain}" />
-    <add key="okta:ClientId" value="{ClientId}" />
-    <add key="okta:AuthorizationServerId" value="default" />
+    <add key="okta:OktaDomain" value="https://{YourOktaDomain}"/>
+    <add key="okta:ClientId" value="{ClientId}"/>
+    <add key="okta:AuthorizationServerId" value="default"/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -19,53 +19,53 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.6.2" />
-    <httpRuntime targetFramework="4.6.1" />
+    <compilation debug="true" targetFramework="4.8.1"/>
+    <httpRuntime targetFramework="4.6.1"/>
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Hosting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="Microsoft.Owin.Hosting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  
   <system.codedom>
     <compilers>
-      <compiler extension=".cs" language="c#;cs;csharp" warningLevel="4" compilerOptions="/langversion:7.0 /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-      <compiler extension=".vb" language="vb;vbs;visualbasic;vbscript" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      <compiler extension=".cs" language="c#;cs;csharp" warningLevel="4" compilerOptions="/langversion:7.0 /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+      <compiler extension=".vb" language="vb;vbs;visualbasic;vbscript" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
     </compilers>
   </system.codedom>
-<system.webServer>
+  <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
-  </system.webServer></configuration>
+  </system.webServer>
+</configuration>

--- a/Okta.AspNet.WebApi.IntegrationTest/packages.config
+++ b/Okta.AspNet.WebApi.IntegrationTest/packages.config
@@ -1,34 +1,34 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.8" targetFramework="net462" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.8" targetFramework="net462" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.8" targetFramework="net462" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.8" targetFramework="net462" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.8" targetFramework="net462" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net461" requireReinstallation="true" />
-  <package id="Microsoft.Net.Compilers" version="4.1.0" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net462" />
-  <package id="Microsoft.Owin.Hosting" version="4.2.1" targetFramework="net462" />
-  <package id="Microsoft.Owin.Security" version="4.2.2" targetFramework="net462" />
-  <package id="Microsoft.Owin.Security.OAuth" version="4.2.2" targetFramework="net462" />
-  <package id="Microsoft.Owin.Testing" version="4.2.1" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
-  <package id="Owin" version="1.0" targetFramework="net461" />
-  <package id="StyleCop.Analyzers" version="1.2.0-beta.164" targetFramework="net461" developmentDependency="true" />
-  <package id="StyleCop.Analyzers.Unstable" version="1.2.0.406" targetFramework="net462" developmentDependency="true" />
-  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net461" requireReinstallation="true" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net461" />
-  <package id="xunit" version="2.4.1" targetFramework="net461" />
-  <package id="xunit.abstractions" version="2.0.3" targetFramework="net461" />
-  <package id="xunit.analyzers" version="0.10.0" targetFramework="net461" />
-  <package id="xunit.assert" version="2.4.1" targetFramework="net461" />
-  <package id="xunit.core" version="2.4.1" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net461" />
-  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net461" />
-  <package id="xunit.runner.console" version="2.4.1" targetFramework="net461" developmentDependency="true" requireReinstallation="true" />
-  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net461" developmentDependency="true" />
+  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.8" targetFramework="net481" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.8" targetFramework="net481" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.8" targetFramework="net481" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.8" targetFramework="net481" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.8" targetFramework="net481" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net481" requireReinstallation="true" />
+  <package id="Microsoft.Net.Compilers" version="4.1.0" targetFramework="net481" developmentDependency="true" />
+  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net481" />
+  <package id="Microsoft.Owin.Hosting" version="4.2.1" targetFramework="net481" />
+  <package id="Microsoft.Owin.Security" version="4.2.2" targetFramework="net481" />
+  <package id="Microsoft.Owin.Security.OAuth" version="4.2.2" targetFramework="net481" />
+  <package id="Microsoft.Owin.Testing" version="4.2.1" targetFramework="net481" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net481" />
+  <package id="Owin" version="1.0" targetFramework="net481" />
+  <package id="StyleCop.Analyzers" version="1.2.0-beta.164" targetFramework="net481" developmentDependency="true" />
+  <package id="StyleCop.Analyzers.Unstable" version="1.2.0.406" targetFramework="net481" developmentDependency="true" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net481" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net481" requireReinstallation="true" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net481" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net481" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net481" />
+  <package id="xunit" version="2.4.1" targetFramework="net481" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net481" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net481" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net481" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net481" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net481" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net481" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net481" developmentDependency="true" requireReinstallation="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net481" developmentDependency="true" />
 </packages>

--- a/Okta.AspNet.WebApi.IntegrationTest/packages.config
+++ b/Okta.AspNet.WebApi.IntegrationTest/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.8" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.8" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.8" targetFramework="net462" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net461" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net461" requireReinstallation="true" />
   <package id="Microsoft.Net.Compilers" version="4.1.0" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net462" />
   <package id="Microsoft.Owin.Hosting" version="4.2.1" targetFramework="net462" />
@@ -18,7 +18,7 @@
   <package id="StyleCop.Analyzers" version="1.2.0-beta.164" targetFramework="net461" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.406" targetFramework="net462" developmentDependency="true" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net461" />
@@ -29,6 +29,6 @@
   <package id="xunit.core" version="2.4.1" targetFramework="net461" />
   <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net461" />
   <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net461" />
-  <package id="xunit.runner.console" version="2.4.1" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.runner.console" version="2.4.1" targetFramework="net461" developmentDependency="true" requireReinstallation="true" />
   <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Official Okta middleware for ASP.NET 4.6.2+. Easily add authentication and authorization to ASP.NET applications.</Description>
+    <Description>Official Okta middleware for ASP.NET 4.8.1. Easily add authentication and authorization to ASP.NET applications.</Description>
     <Copyright>(c) 2019 Okta, Inc.</Copyright>
-    <Version>3.2.2</Version>
+    <Version>3.2.3</Version>
     <Authors>Okta, Inc.</Authors>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <AssemblyName>Okta.AspNet</AssemblyName>
     <PackageId>Okta.AspNet</PackageId>
     <PackageTags>okta,token,authentication,authorization,oauth,sso,oidc</PackageTags>
@@ -30,8 +30,8 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>3.0.2.2</AssemblyVersion>
-    <FileVersion>3.0.2.2</FileVersion>
+    <AssemblyVersion>3.0.2.3</AssemblyVersion>
+    <FileVersion>3.0.2.3</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>


### PR DESCRIPTION
- Updated target framework 4.8.1 where appropriate. 
- Allowed Visual Studio to update binding redirects