### PR TITLE
Fix JWT Security Validator issue in .NET

### DIFF
--- a/Okta.AspNet.Abstractions.Test/StrictTokenHandlerShould.cs
+++ b/Okta.AspNet.Abstractions.Test/StrictTokenHandlerShould.cs
@@ -61,7 +61,7 @@ namespace Okta.AspNet.Abstractions.Test
             var fakeAudience = "aud://default";
 
             var credentials = new SigningCredentials(
-                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("extralongtosatisfynewrequirementsfakesigningsecret!")),
                 SecurityAlgorithms.HmacSha256);
 
             // Create the JWT and write it to a string

--- a/Okta.AspNet.Abstractions.Test/TokenValidationShould.cs
+++ b/Okta.AspNet.Abstractions.Test/TokenValidationShould.cs
@@ -22,7 +22,7 @@ namespace Okta.AspNet.Abstractions.Test
             var fakeAudience = "aud://default";
 
             var credentials = new SigningCredentials(
-                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("extralongtosatisfynewrequirementsfakesigningsecret!")),
                 SecurityAlgorithms.HmacSha256);
 
             // Create the JWT and write it to a string
@@ -77,7 +77,7 @@ namespace Okta.AspNet.Abstractions.Test
             var fakeAudience = "aud://default";
 
             var credentials = new SigningCredentials(
-                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("extralongtosatisfynewrequirementsfakesigningsecret!")),
                 SecurityAlgorithms.HmacSha256);
 
             // Create the JWT and write it to a string
@@ -144,7 +144,7 @@ namespace Okta.AspNet.Abstractions.Test
             var fakeAudience = "aud://default";
 
             var credentials = new SigningCredentials(
-                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("extralongtosatisfynewrequirementsfakesigningsecret!")),
                 SecurityAlgorithms.HmacSha256);
 
             // Create the JWT and write it to a string
@@ -180,7 +180,7 @@ namespace Okta.AspNet.Abstractions.Test
             var fakeAudience = "aud://default";
 
             var credentials = new SigningCredentials(
-                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("fakesigningsecret!")),
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes("extralongtosatisfynewrequirementsfakesigningsecret!")),
                 SecurityAlgorithms.HmacSha256);
 
             // Create the JWT and write it to a string

--- a/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
+++ b/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <Version>5.0.0</Version>
+    <TargetFrameworks>net462;netstandard2.0;net8.0</TargetFrameworks>
+    <Version>5.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,10 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.17.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.35.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
@@ -36,8 +35,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.0.0</FileVersion>
+    <AssemblyVersion>5.1.0.0</AssemblyVersion>
+    <FileVersion>5.1.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Okta.AspNet.Test/JwtOptionsBuilderShould.cs
+++ b/Okta.AspNet.Test/JwtOptionsBuilderShould.cs
@@ -20,7 +20,7 @@ namespace Okta.AspNet.Test
 
             var oktaWebApiOptions = new OktaWebApiOptions
             {
-                OktaDomain = "http://myoktadomain.com",
+                OktaDomain = "https://myoktadomain.com",
                 BackchannelTimeout = TimeSpan.FromMinutes(5),
                 BackchannelHttpClientHandler = new MockHttpClientHandler(),
                 OAuthBearerAuthenticationProvider = mockAuthnProvider,

--- a/Okta.AspNet.WebApi.IntegrationTest/Okta.AspNet.WebApi.IntegrationTest.csproj
+++ b/Okta.AspNet.WebApi.IntegrationTest/Okta.AspNet.WebApi.IntegrationTest.csproj
@@ -47,10 +47,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.6.35.0\lib\net462\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.6.35.0\lib\net462\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.6.35.0\lib\net462\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.6.35.0\lib\net462\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
@@ -93,6 +108,9 @@
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.6.35.0\lib\net462\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
@@ -110,8 +128,8 @@
       <HintPath>..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
@@ -127,8 +145,17 @@
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.4.7.2\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/Okta.AspNet.WebApi.IntegrationTest/packages.config
+++ b/Okta.AspNet.WebApi.IntegrationTest/packages.config
@@ -6,7 +6,12 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.3.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.3.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.3.0" targetFramework="net462" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="6.35.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Logging" version="6.35.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Tokens" version="6.35.0" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="4.1.0" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net462" />
   <package id="Microsoft.Owin.Hosting" version="4.2.2" targetFramework="net462" />
@@ -22,16 +27,21 @@
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.406" targetFramework="net462" developmentDependency="true" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="6.35.0" targetFramework="net462" />
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net462" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net462" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net462" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net462" />
+  <package id="System.Text.Json" version="4.7.2" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
   <package id="xunit" version="2.7.0" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
   <package id="xunit.analyzers" version="1.11.0" targetFramework="net462" />

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Official Okta middleware for ASP.NET 4.6.2+. Easily add authentication and authorization to ASP.NET applications.</Description>
     <Copyright>(c) 2019 Okta, Inc.</Copyright>
-    <Version>3.2.3</Version>
+    <Version>3.2.4</Version>
     <Authors>Okta, Inc.</Authors>
     <TargetFramework>net462</TargetFramework>
     <AssemblyName>Okta.AspNet</AssemblyName>
@@ -24,14 +24,14 @@
     <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect" Version="4.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
-    <AssemblyVersion>3.2.3.0</AssemblyVersion>
-    <FileVersion>3.2.3.0</FileVersion>
+    <AssemblyVersion>3.2.4.0</AssemblyVersion>
+    <FileVersion>3.2.4.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -8,7 +8,7 @@
 		<Description>Official Okta middleware for ASP.NET Core 3.1+. Easily add authentication and authorization to ASP.NET Core applications.</Description>
 		<Copyright>(c) 2020 - present Okta, Inc. All rights reserved.</Copyright>
 		<Version>4.6.0</Version>
-		<VersionPrefix>4.6.0</VersionPrefix>
+		<VersionPrefix>4.6.1</VersionPrefix>
 		<Authors>Okta, Inc.</Authors>
 		<AssemblyName>Okta.AspNetCore</AssemblyName>
 		<PackageId>Okta.AspNetCore</PackageId>

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -7,7 +7,7 @@
 	<PropertyGroup>
 		<Description>Official Okta middleware for ASP.NET Core 3.1+. Easily add authentication and authorization to ASP.NET Core applications.</Description>
 		<Copyright>(c) 2020 - present Okta, Inc. All rights reserved.</Copyright>
-		<Version>4.6.0</Version>
+		<Version>4.6.1</Version>
 		<VersionPrefix>4.6.1</VersionPrefix>
 		<Authors>Okta, Inc.</Authors>
 		<AssemblyName>Okta.AspNetCore</AssemblyName>

--- a/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
+++ b/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
@@ -37,7 +37,9 @@ namespace Okta.AspNetCore
             oidcOptions.SignedOutRedirectUri = oktaMvcOptions.PostLogoutRedirectUri;
             oidcOptions.ResponseType = OpenIdConnectResponseType.Code;
             oidcOptions.GetClaimsFromUserInfoEndpoint = oktaMvcOptions.GetClaimsFromUserInfoEndpoint;
+
 #if NET8_0_OR_GREATER
+            oidcOptions.UseSecurityTokenValidator = true;
             oidcOptions.TokenHandler = new StrictTokenHandler();
 #else
             oidcOptions.SecurityTokenValidator = new StrictSecurityTokenValidator();

--- a/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
+++ b/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
@@ -40,10 +40,8 @@ namespace Okta.AspNetCore
 
 #if NET8_0_OR_GREATER
             oidcOptions.UseSecurityTokenValidator = true;
-            oidcOptions.TokenHandler = new StrictTokenHandler();
-#else
-            oidcOptions.SecurityTokenValidator = new StrictSecurityTokenValidator();
 #endif
+            oidcOptions.SecurityTokenValidator = new StrictSecurityTokenValidator();
             oidcOptions.SaveTokens = true;
             oidcOptions.UseTokenLifetime = false;
             oidcOptions.BackchannelHttpHandler = new OktaHttpMessageHandler(


### PR DESCRIPTION
- Upgrade vuln dependencies (System.IdentityModel.Tokens.Jwt to 6.35)
- Add oidcOptions.UseSecurityTokenValidator = true setting for .NET 8 projects to keep using JwtSecurityToken (https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/8.0/securitytoken-events)
- Add .NET8 as a valid frameworkTarget for Okta.AspNet.Abstractions
- Update updated project's version in prep for an upcoming release
- Fix #260 #261 #259 
