### PR TITLE
Fix: Replace RuntimeInformation dependency with Environment.Version for .NET 8+

### DIFF
--- a/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
+++ b/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System;
 using System.Runtime.InteropServices;
 using FluentAssertions;
 using Xunit;
@@ -65,18 +66,14 @@ namespace Okta.AspNet.Abstractions.Test
         [Fact]
         public void FrameworkDescriptionShouldReturnCorrectValueBasedOnRuntime()
         {
-            var runtimeFrameworkDescrition = string.Empty;
             #if NET8_0_OR_GREATER
             var expectedFrameworkDescription = Environment.Version.ToString();
             #else
             var expectedFrameworkDescription = RuntimeInformation.FrameworkDescription;
             #endif
-            var frameworkDescription = string.IsNullOrEmpty(runtimeFrameworkDescrition)
-                ?expectedFrameworkDescription
-                : runtimeFrameworkDescrition;
-            Assert.NotNull(frameworkDescription);
-            Assert.Equal(expectedFrameworkDescription, frameworkDescription);
-        }
+            var frameworkDescription = UserAgentHelper.GetFrameworkDescription();
+            frameworkDescription.Should().Be(expectedFrameworkDescription);
+        }       
         
     }
 }

--- a/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
+++ b/Okta.AspNet.Abstractions.Test/UserAgentHelperShould.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Xunit;
 
@@ -60,5 +61,22 @@ namespace Okta.AspNet.Abstractions.Test
 
             frameworkInfo.Should().Be(".NET Core foo");
         }
+
+        [Fact]
+        public void FrameworkDescriptionShouldReturnCorrectValueBasedOnRuntime()
+        {
+            var runtimeFrameworkDescrition = string.Empty;
+            #if NET8_0_OR_GREATER
+            var expectedFrameworkDescription = Environment.Version.ToString();
+            #else
+            var expectedFrameworkDescription = RuntimeInformation.FrameworkDescription;
+            #endif
+            var frameworkDescription = string.IsNullOrEmpty(runtimeFrameworkDescrition)
+                ?expectedFrameworkDescription
+                : runtimeFrameworkDescrition;
+            Assert.NotNull(frameworkDescription);
+            Assert.Equal(expectedFrameworkDescription, frameworkDescription);
+        }
+        
     }
 }

--- a/Okta.AspNet.Abstractions/UserAgentHelper.cs
+++ b/Okta.AspNet.Abstractions/UserAgentHelper.cs
@@ -22,7 +22,13 @@ namespace Okta.AspNet.Abstractions
         /// <returns>The normalized framework desctiption.</returns>
         public static string GetFrameworkDescription(string runtimeFrameworkDescription = "", string runtimeAssemblyCodeBase = "")
         {
+            #if NET8_0_OR_GREATER
+            /* For .NET 8.0 and newer, use Environment.Version for framework description */
+            var frameworkDescription = string.IsNullOrEmpty(runtimeFrameworkDescription) ? Environment.Version.ToString() : runtimeFrameworkDescription;
+            #else
+            /* For Older .Net versions, continue using RuntimeInformation.FrameworkDescription for framework description */
             var frameworkDescription = string.IsNullOrEmpty(runtimeFrameworkDescription) ? RuntimeInformation.FrameworkDescription : runtimeFrameworkDescription;
+            #endif
             var assemblyCodeBase = runtimeAssemblyCodeBase;
 
             // RuntimeInformation.FrameworkDescription only returns the CLI version for .NET Core.


### PR DESCRIPTION
This pull request addresses an issue related to the use of RuntimeInformation.FrameworkDescription in the UserAgentHelper class of the Okta.AspNet.Abstractions library. The change replaces the dependency on RuntimeInformation with Environment.Version for projects targeting .NET 5 and above. The goal is to reduce unnecessary dependencies, especially in modern .NET versions, by utilizing Environment.Version to obtain framework version details.

Changes Made:
- Replaced the usage of RuntimeInformation.FrameworkDescription with Environment.Version.ToString() for .NET 8+ versions.
- Used conditional compilation to handle differences between .NET 8 and older versions.
- Updated the logic in UserAgentHelper to ensure proper fallback behavior based on the runtime framework version.
- Added integration test to verify the correct assignment of the framework description across different .NET versions.

Testing Done:
- All unit tests were re-run to ensure existing functionality was preserved.
- Added a new integration test to verify the functionality of the frameworkDescription logic.
- Verified that the framework description is correctly retrieved for both .NET 8+ and earlier versions.

Related Issues:
-[#274](https://github.com/okta/okta-aspnet/issues/274)