### PR TITLE
Update vulnerable packages to resolve security issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.preferCSharpExtension": true
+}

--- a/Okta.AspNet.Abstractions.Test/Okta.AspNet.Abstractions.Test.csproj
+++ b/Okta.AspNet.Abstractions.Test/Okta.AspNet.Abstractions.Test.csproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Okta.AspNet.Abstractions/CHANGELOG.md
+++ b/Okta.AspNet.Abstractions/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Running changelog of releases since `3.0.5`
 
+## v5.1.2
+- Vulnerable Package Upgrades
+- Increase in Backchannel Timeout 
+
 ## v5.1.1
 
 - Replace RuntimeInformation dependency with Environment.Version for .Net8+ (#275)

--- a/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
+++ b/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 

--- a/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
+++ b/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;net8.0</TargetFrameworks>
-    <Version>5.1.1</Version>
+    <Version>5.1.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Okta.AspNet.Test/Okta.AspNet.Test.csproj
+++ b/Okta.AspNet.Test/Okta.AspNet.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Okta.AspNet.WebApi.IntegrationTest/Okta.AspNet.WebApi.IntegrationTest.csproj
+++ b/Okta.AspNet.WebApi.IntegrationTest/Okta.AspNet.WebApi.IntegrationTest.csproj
@@ -47,8 +47,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=9.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.9.0.3\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -111,6 +111,9 @@
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.6.35.0\lib\net462\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Pipelines, Version=9.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.9.0.3\lib\net462\System.IO.Pipelines.dll</HintPath>
+    </Reference>
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
@@ -128,8 +131,8 @@
       <HintPath>..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
@@ -145,11 +148,11 @@
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.4.7.2\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=9.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.9.0.3\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=9.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.9.0.3\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Okta.AspNet.WebApi.IntegrationTest/Web.config
+++ b/Okta.AspNet.WebApi.IntegrationTest/Web.config
@@ -52,6 +52,18 @@
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.3" newVersion="9.0.0.3" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   

--- a/Okta.AspNet.WebApi.IntegrationTest/packages.config
+++ b/Okta.AspNet.WebApi.IntegrationTest/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.3.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.3.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.3.0" targetFramework="net462" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.3" targetFramework="net462" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Abstractions" version="6.35.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" targetFramework="net462" />
@@ -28,18 +28,19 @@
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
   <package id="System.IdentityModel.Tokens.Jwt" version="6.35.0" targetFramework="net462" />
+  <package id="System.IO.Pipelines" version="9.0.3" targetFramework="net462" />
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net462" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net462" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net462" />
-  <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net462" />
-  <package id="System.Text.Json" version="4.7.2" targetFramework="net462" />
+  <package id="System.Text.Encodings.Web" version="9.0.3" targetFramework="net462" />
+  <package id="System.Text.Json" version="9.0.3" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
   <package id="xunit" version="2.7.0" targetFramework="net462" />

--- a/Okta.AspNet/CHANGELOG.md
+++ b/Okta.AspNet/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Running changelog of releases since `1.6.0`
 
+## v3.2.6
+- Vulnerable Package Upgrades
+- Upgrade in Okta.AspNet.Abstractions
+
 ## v3.2.5
 
 - Replace RuntimeInformation dependency with Environment.Version for .Net8+ (#275) for Okta.AspNet.Abstractions.

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Official Okta middleware for ASP.NET 4.6.2+. Easily add authentication and authorization to ASP.NET applications.</Description>
     <Copyright>(c) 2019 Okta, Inc.</Copyright>
-    <Version>3.2.5</Version>
+    <Version>3.2.6</Version>
     <Authors>Okta, Inc.</Authors>
     <TargetFramework>net462</TargetFramework>
     <AssemblyName>Okta.AspNet</AssemblyName>

--- a/Okta.AspNetCore.Mvc.IntegrationTest/Okta.AspNetCore.Mvc.IntegrationTest.csproj
+++ b/Okta.AspNetCore.Mvc.IntegrationTest/Okta.AspNetCore.Mvc.IntegrationTest.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Okta.AspNetCore.Test/Okta.AspNetCore.Test.csproj
+++ b/Okta.AspNetCore.Test/Okta.AspNetCore.Test.csproj
@@ -10,6 +10,9 @@
     <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">

--- a/Okta.AspNetCore.WebApi.IntegrationTest/Okta.AspNetCore.WebApi.IntegrationTest.csproj
+++ b/Okta.AspNetCore.WebApi.IntegrationTest/Okta.AspNetCore.WebApi.IntegrationTest.csproj
@@ -8,6 +8,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.21" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Okta.AspNetCore/CHANGELOG.md
+++ b/Okta.AspNetCore/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Running changelog of releases since `3.2.0`
 
+## v4.6.3
+- Vulnerable Package Upgrades
+- Upgrade in Okta.AspNet.Abstractions
+
 ## v4.6.2
 
 - Replace RuntimeInformation dependency with Environment.Version for .Net8+ (#275) for Okta.AspNet.Abstractions.

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -7,9 +7,8 @@
 	<PropertyGroup>
 		<Description>Official Okta middleware for ASP.NET Core 3.1+. Easily add authentication and authorization to ASP.NET Core applications.</Description>
 		<Copyright>(c) 2020 - present Okta, Inc. All rights reserved.</Copyright>
-		<Version>4.6.2</Version>
-		<VersionPrefix>4.6.2</VersionPrefix>
-		<Authors>Okta, Inc.</Authors>
+		<Version>4.6.3</Version>
+		<VersionPrefix>4.6.3</Authors>
 		<AssemblyName>Okta.AspNetCore</AssemblyName>
 		<PackageId>Okta.AspNetCore</PackageId>
 		<PackageTags>okta,token,authentication,authorization</PackageTags>

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -26,6 +26,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="System.Text.Json" Version="9.0.3" />
 		<AdditionalFiles Include="..\stylecop.json" />
 	</ItemGroup>
 


### PR DESCRIPTION
### Description
Fixes the issue #269 with outdated package dependencies causing security vulnerabilities.

### Why is this change necessary?
The outdated versions of these packages contain known security vulnerabilities that could be exploited, leading to potential breaches. Updating these dependencies ensures compliance with security policies and improves the overall security posture of the project.

### Testing
Verified the updated package versions using dotnet list package --include-transitive.
Ran security scanning tools (dotnet retire) to confirm that the vulnerabilities are resolved.
Built and tested the solution to ensure no breaking changes were introduced.
Triggered the snyk scan to verify no vulnerable component found