### PR TITLE
feat: Use JsonWebTokenHandler in .NET 8 for improved token handling

### DIFF
--- a/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
+++ b/Okta.AspNetCore/OpenIdConnectOptionsHelper.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Okta.AspNet.Abstractions;
 
@@ -39,7 +40,7 @@ namespace Okta.AspNetCore
             oidcOptions.GetClaimsFromUserInfoEndpoint = oktaMvcOptions.GetClaimsFromUserInfoEndpoint;
 
 #if NET8_0_OR_GREATER
-            oidcOptions.UseSecurityTokenValidator = true;
+            oidcOptions.TokenHandler = new JsonWebTokenHandler();
 #endif
             oidcOptions.SecurityTokenValidator = new StrictSecurityTokenValidator();
             oidcOptions.SaveTokens = true;
@@ -98,7 +99,7 @@ namespace Okta.AspNetCore
             };
 #if NET8_0_OR_GREATER
             jwtBearerOptions.TokenHandlers.Clear();
-            jwtBearerOptions.TokenHandlers.Add(new StrictTokenHandler());
+            jwtBearerOptions.TokenHandlers.Add(new JsonWebTokenHandler());
 
 #else
             jwtBearerOptions.SecurityTokenValidators.Clear();


### PR DESCRIPTION
This pull request fixes #263 updates the Okta ASP.NET library to utilize `JsonWebTokenHandler` instead of `StrictSecurityTokenValidator` and `StrictTokenHandler` for token validation in .NET 8.

This change aligns with the recommendations in ASP.NET Core 8.0 for improved performance, reliability, and asynchronous processing of JWTs, as outlined in the Microsoft documentation [link to the Microsoft article you shared].

**Key changes:**

* Replaced conditional usage of `StrictSecurityTokenValidator`/`StrictTokenHandler` with `JsonWebTokenHandler` in `OpenIdConnectOptionsHelper.cs` for both OpenID Connect and JWT Bearer flows.