### PR TITLE
docs: update README compatibility requirements for .NET Framework 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This library uses semantic versioning and follows Okta's [library version policy
 
 |Package| Version | Status                    | Compatibility|
 | ------- | ------- | ------------------------- | ----------------------- |
-|`Okta.AspNet.Abstractions`| 5.x   | :heavy_check_mark: Stable | .NET Standard 2.0 and .NET Framework 4.6.2 or higher.|
+|`Okta.AspNet.Abstractions`| 5.x   | :heavy_check_mark: Stable | .NET Standard 2.0 and .NET Framework 4.8 or higher.|
 |`Okta.AspNet.Abstractions`| 4.x   | :warning: Retiring November 28th, 2023 | .NET Standard 2.0 and .NET Framework 4.5.2 or higher.|
-|`Okta.AspNet`| 3.x | :heavy_check_mark: Stable | .NET Framework 4.6.2 |
+|`Okta.AspNet`| 3.x | :heavy_check_mark: Stable | .NET Framework 4.8 |
 |`Okta.AspNet`| 2.x | :warning: Retiring | .NET Framework 4.5.2 |
 |`Okta.AspNetCore`| 4.x | :heavy_check_mark: Stable | .NET Core 3.x, .NET 5.0, .NET 6.0, .NET 7.0 and .NET 8.0 |
 |`Okta.AspNetCore`| 3.x | :warning: Retiring | .NET Standard 2.0 and .NET Core 2.x |


### PR DESCRIPTION
## Summary
Updates the README documentation to reflect the new .NET Framework 4.8 minimum requirements following the recent framework upgrade.

## Changes Made
- Updated `Okta.AspNet.Abstractions` 5.x compatibility from ".NET Framework 4.6.2 or higher" to ".NET Framework 4.8 or higher"
- Updated `Okta.AspNet` 3.x compatibility from ".NET Framework 4.6.2" to ".NET Framework 4.8"

## Context
This documentation update aligns with the recent upgrade of all .NET Framework projects from 4.6.2 to 4.8 to ensure users have accurate information about minimum framework requirements.

## Impact
- ✅ Documentation accuracy improved
- ✅ Clear guidance for developers on framework requirements
- ✅ Consistent with actual project configurations

## Checklist
- [x] README table updated with correct framework versions
- [x] Changes are minimal and focused on accuracy
- [x] No breaking documentation changes