### PR TITLE
chore(ci): add Snyk SCA scan (Windows) and remove malware scanner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,76 +3,45 @@ version: 2.1
 orbs:
   windows: circleci/windows@5.0
   general-platform-helpers: okta/general-platform-helpers@1.9
-  python: circleci/python@2.0.3
-  aws-cli: circleci/aws-cli@5.1
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  reversing-labs:
-    steps:
-      - checkout
-  
-      - run: dotnet --version
-
-      - run: 
-          name: build Binary to scan
-          command: dotnet build ./src/Okta.AspNet.sln
-       
-      // Necessary to Install rl wrapper   
-      - run:
-          name: Install Python
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y python3 python3-pip
-            sudo pip install --upgrade pip
-  
-      // Download the scanner from Okta Security
-      - run:
-          name: Download Reverse Labs Scanner
-          command: |
-            curl https://dso-resources.oktasecurity.com/scanner \
-              -H "x-api-key: $DSO_RLSECURE_TOKEN" \
-              --output rl_wrapper-0.0.2+35ababa-py3-none-any.whl
-      // Install the wrapper that was downloaded
-      - run:
-          name: Install RL Wrapper
-          command: |
-            pip install ./rl_wrapper-0.0.2+35ababa-py3-none-any.whl
-  
-      // Setup the AWS profile
-      - aws-cli/setup:
-          profile_name: default
-          role_arn: $AWS_ARN
-          region: us-east-1
-  
-      // Get the credentials and save to env
-      - run: >-
-          eval "$(aws configure export-credentials --profile default --format env)" 2> /dev/null
-  
-      // Run the wrapper, do not change anything here
-      - run:
-          name: Run Reversing Labs Wrapper Scanner
-          command: |
-            rl-wrapper \
-              --artifact ${CIRCLE_WORKING_DIRECTORY/#\~/$HOME} \
-              --name $CIRCLE_PROJECT_REPONAME\
-              --version $CIRCLE_SHA1\
-              --repository $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
-              --commit $CIRCLE_SHA1 \
-              --build-env "circleci" \
-              --suppress_output
-
   build:
     executor:
       name: windows/default
     environment:
       CIRCLE_CI: True
     steps:
-      - checkout      
+      - run:
+          name: Manual HTTPS checkout (avoid SSH)
+          command: |
+            git --version
+            if (Test-Path .git) { Remove-Item -Recurse -Force .git }
+            git init .
+            git remote add origin https://github.com/$env:CIRCLE_PROJECT_USERNAME/$env:CIRCLE_PROJECT_REPONAME.git
+            git fetch --depth=1 origin $env:CIRCLE_SHA1
+            git checkout --force $env:CIRCLE_SHA1
       - run:
           name: "build okta aspnet"
           command: .\build.ps1
+      - persist_to_workspace: # Share code, git metadata, and build artifacts for Snyk scan
+          root: ~/project
+          paths:
+            - .git
+            - artifacts
+            - Okta.AspNet
+            - Okta.AspNet.Abstractions
+            - Okta.AspNet.Abstractions.Test
+            - Okta.AspNet.Test
+            - Okta.AspNetCore
+            - Okta.AspNetCore.Mvc.IntegrationTest
+            - Okta.AspNetCore.Test
+            - Okta.AspNetCore.WebApi.IntegrationTest
+            - Okta.AspNet.WebApi.IntegrationTest
+            - packages
+            - tools
+            - Okta.AspNet.sln
       - when:
           condition:
             equal: [ "<<pipeline.git.branch>>", "master" ]
@@ -81,14 +50,48 @@ jobs:
                 files-to-upload: "artifacts"
                 location: "com/okta/devex/okta-aspnet"
 
+  # Snyk Software Composition Analysis (SCA) scan on Windows to support net48/packages.config
+  snyk-scan:
+    executor:
+      name: windows/default
+    working_directory: ~/project
+    environment:
+      SNYK_DISABLE_ANALYTICS: "1"
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Download Snyk CLI (Windows standalone)
+          command: |
+            $ErrorActionPreference = 'Stop'
+            $snykDir = Join-Path $env:USERPROFILE 'snyk'
+            New-Item -ItemType Directory -Force -Path $snykDir | Out-Null
+            $snykExe = Join-Path $snykDir 'snyk.exe'
+            Invoke-WebRequest -UseBasicParsing -Uri 'https://static.snyk.io/cli/latest/snyk-win.exe' -OutFile $snykExe
+            & $snykExe --version
+      - run:
+          name: Run Snyk monitor (Windows; exclude tools and packages only)
+          command: |
+            $ErrorActionPreference = 'Stop'
+            $env:SNYK_DISABLE_ANALYTICS = "1"
+            if (-not (Test-Path .git)) { Write-Error "No .git found"; exit 1 }
+            $snykExe = Join-Path $env:USERPROFILE 'snyk/snyk.exe'
+            $EXCLUDES = 'tools,packages'
+            & $snykExe monitor `
+              --all-projects `
+              --detection-depth=4 `
+              --prune-repeated-subdependencies `
+              --exclude=$EXCLUDES
+
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  "Malware Scanner":
-    jobs:
-      - reversing-labs:
-          context:
-            - static-analysis
-  "Circle CI Build":
+  "Circle CI Build & Snyk Scan":
     jobs:
       - build
+      - snyk-scan:
+          name: execute-snyk
+          context:
+            - static-analysis
+          requires:
+            - build


### PR DESCRIPTION
- Add Snyk SCA to CircleCI using Windows executor and standalone CLI
- Remove Reversing Labs malware scanner job/workflow
- Support .NET Framework 4.8 and packages.config; exclude only tools and packages
- Avoid npm/Python installs; fix prior Linux platform issues