### PR TITLE
fix: Switch from DelaySign to PublicSign for strong naming

### DIFF
--- a/Okta.AspNet.Abstractions.Test/Okta.AspNet.Abstractions.Test.csproj
+++ b/Okta.AspNet.Abstractions.Test/Okta.AspNet.Abstractions.Test.csproj
@@ -38,7 +38,7 @@
 	<CodeAnalysisRuleSet>..\OktaSdk.Tests.ruleset</CodeAnalysisRuleSet>
 	<SignAssembly>true</SignAssembly>
 	<AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-	<DelaySign>true</DelaySign>
+	<PublicSign>true</PublicSign>
   </PropertyGroup>
 
 </Project>

--- a/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
+++ b/Okta.AspNet.Abstractions/Okta.AspNet.Abstractions.csproj
@@ -32,9 +32,9 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>true</DelaySign>
+    	<SignAssembly>true</SignAssembly>
+	<AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
+	<PublicSign>true</PublicSign>
     <AssemblyVersion>5.1.6.0</AssemblyVersion>
     <FileVersion>5.1.6.0</FileVersion>
   </PropertyGroup>

--- a/Okta.AspNet.Test/Okta.AspNet.Test.csproj
+++ b/Okta.AspNet.Test/Okta.AspNet.Test.csproj
@@ -35,7 +35,7 @@
     <CodeAnalysisRuleSet>..\OktaSdk.Tests.ruleset</CodeAnalysisRuleSet>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>true</DelaySign>
+    <PublicSign>true</PublicSign>
   </PropertyGroup>
 
 </Project>

--- a/Okta.AspNet/Okta.AspNet.csproj
+++ b/Okta.AspNet/Okta.AspNet.csproj
@@ -38,7 +38,7 @@
     <FileVersion>3.2.10.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>true</DelaySign>
+    <PublicSign>true</PublicSign>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Okta.AspNetCore.Mvc.IntegrationTest/Okta.AspNetCore.Mvc.IntegrationTest.csproj
+++ b/Okta.AspNetCore.Mvc.IntegrationTest/Okta.AspNetCore.Mvc.IntegrationTest.csproj
@@ -35,7 +35,7 @@
 	<CodeAnalysisRuleSet>..\OktaSdk.Tests.ruleset</CodeAnalysisRuleSet>
 	<SignAssembly>true</SignAssembly>
 	<AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-	<DelaySign>true</DelaySign>
+	<PublicSign>true</PublicSign>
   </PropertyGroup>
 
 </Project>

--- a/Okta.AspNetCore.Test/Okta.AspNetCore.Test.csproj
+++ b/Okta.AspNetCore.Test/Okta.AspNetCore.Test.csproj
@@ -35,7 +35,7 @@
 	<CodeAnalysisRuleSet>..\OktaSdk.Tests.ruleset</CodeAnalysisRuleSet>
 	<SignAssembly>true</SignAssembly>
 	<AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-	<DelaySign>true</DelaySign>
+	<PublicSign>true</PublicSign>
   </PropertyGroup>
 
 </Project>

--- a/Okta.AspNetCore.WebApi.IntegrationTest/Okta.AspNetCore.WebApi.IntegrationTest.csproj
+++ b/Okta.AspNetCore.WebApi.IntegrationTest/Okta.AspNetCore.WebApi.IntegrationTest.csproj
@@ -31,7 +31,7 @@
 	  <CodeAnalysisRuleSet>..\OktaSdk.Tests.ruleset</CodeAnalysisRuleSet>
 	  <SignAssembly>true</SignAssembly>
 	  <AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-	  <DelaySign>true</DelaySign>
+	  <PublicSign>true</PublicSign>
   </PropertyGroup>
 
 </Project>

--- a/Okta.AspNetCore/Okta.AspNetCore.csproj
+++ b/Okta.AspNetCore/Okta.AspNetCore.csproj
@@ -70,9 +70,9 @@
 
 	<PropertyGroup>
 		<CodeAnalysisRuleSet>..\OktaSdk.ruleset</CodeAnalysisRuleSet>
-		<SignAssembly>true</SignAssembly>
-		<AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
-		<DelaySign>true</DelaySign>
+	<SignAssembly>true</SignAssembly>
+	<AssemblyOriginatorKeyFile>okta.aspnet.public.snk</AssemblyOriginatorKeyFile>
+	<PublicSign>true</PublicSign>
 		<AssemblyVersion>4.6.7.0</AssemblyVersion>
 		<FileVersion>4.6.7.0</FileVersion>
 	</PropertyGroup>

--- a/build.cake
+++ b/build.cake
@@ -86,7 +86,6 @@ Task("Build")
 Task("RunTests")
 .IsDependentOn("Restore")
 .IsDependentOn("Build")
-.IsDependentOn("Strongname")
 .Does(() =>
 {
     Projects
@@ -97,49 +96,14 @@ Task("RunTests")
     });
 });
 
-Task("Strongname")
-.IsDependentOn("Build")
-.Does(() =>
-{    
-    var snBinaries = GetFiles("./Okta.AspNet/bin/Release/net4*/Okta.AspNet.dll")
-                    .Concat(GetFiles("./Okta.AspNet.Abstractions/bin/Release/net4*/Okta.AspNet.Abstractions.dll"))
-                    .Concat(GetFiles("./Okta.AspNetCore/bin/Release/net4*/Okta.AspNetCore.dll"))
-                    .Concat(GetFiles("./Okta.AspNet.Test/bin/Release/net4*/Okta.AspNet.Test.dll"));
-
-    // Use full path to sn.exe as recommended by CircleCI team
-    var snExePath = @"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\sn.exe";
-    
-    // Fallback to sn.exe in PATH for local development
-    if (!System.IO.File.Exists(snExePath))
-    {
-        snExePath = "sn.exe";
-    }
-
-    foreach (var binary in snBinaries)
-    {
-        Information($"Attempting to complete strong name signing for: {binary}");
-        
-        try 
-        {
-            // Complete delay signing with key container
-            StartProcess(snExePath, $"-Rc \"{binary}\" OktaDotnetStrongname");
-            Information($"Successfully applied strong name signature to: {binary}");
-        }
-        catch (Exception ex)
-        {
-            Warning($"Could not complete strong name signing for {binary}: {ex.Message}");
-            Warning("This is expected in development environments without the private key container.");
-            Warning("The assembly remains delay-signed with correct public key token: a5a8152428dc4790");
-        }
-    }
-    
-    Information("Strong name signing process completed. In production CI, assemblies should be fully signed.");
-    Information("In development, assemblies remain delay-signed which is sufficient for debugging.");
-});
+// Note: The Strongname task has been removed.
+// The project now uses PublicSign instead of DelaySign, which embeds the public key
+// at compile time without requiring a private key or post-build sn.exe step.
+// This is Microsoft's recommended approach for open-source projects.
+// See: https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming
 
 Task("PackNuget")
 .IsDependentOn("RunTests")
-.IsDependentOn("Strongname")
 .Does(() =>
 {
     Projects
@@ -189,7 +153,6 @@ Task("Default")
     .IsDependentOn("Clean")
     .IsDependentOn("Restore")
     .IsDependentOn("Build")
-    .IsDependentOn("Strongname")
     .IsDependentOn("RunTests")
     .IsDependentOn("PackNuget");
     


### PR DESCRIPTION
Fixes #303

## Problem
Assemblies built on CircleCI fail with 'Strong name signature could not be verified' on Windows Server deployments.

## Solution
- Replace `DelaySign=true` with `PublicSign=true` in all csproj files
- Remove the `Strongname` task from build.cake (no longer needed)

PublicSign is Microsoft's recommended approach for open-source projects. It embeds the public key at compile time without requiring a private key.