### PR TITLE
ci: remove redundant artifact upload step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,6 @@ jobs:
     description: Run tests and build
     executor:
       name: windows/default
-    environment:
-      CIRCLE_CI: True
     steps:
       - run:
           name: Checkout with HTTPS
@@ -117,13 +115,6 @@ jobs:
           root: .
           paths:
             - .
-      - when:
-          condition:
-            equal: [ "<<pipeline.git.branch>>", "master" ]
-          steps:
-            - general-platform-helpers/step-artifacts-prepare-and-upload-windows:
-                files-to-upload: "artifacts"
-                location: "com/okta/devex/okta-aspnet"
 
   snyk-scan:
     docker:


### PR DESCRIPTION
Removes the step-artifacts-prepare-and-upload-windows step from the Build job. Artifact publishing is now handled by the internal pipeline, so this step is no longer needed and was causing failures on master.\n\nNo impact to build, test, or security scan jobs.